### PR TITLE
sets/exports: allow arch. specific override of RECONF

### DIFF
--- a/sets/exports.json
+++ b/sets/exports.json
@@ -40,6 +40,7 @@
     "AB_SAN_LEK",
     "NOLTO",
     "NOSTATIC",
+    "RECONF",
     "ABPATCHLAX"
   ],
   "offical_builds": [


### PR DESCRIPTION
This PR allows RECONF to be overridden by arch. specific requirements.