### PR TITLE
4.1: Spiral Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /build
 /cmake-build-*
 compile_commands.json
+.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(autobuild VERSION 4.0.29 HOMEPAGE_URL "https://github.com/AOSC-Dev/autobuild4" LANGUAGES C CXX)
+project(autobuild VERSION 4.1.0 HOMEPAGE_URL "https://github.com/AOSC-Dev/autobuild4" LANGUAGES C CXX)
 
 include(GNUInstallDirs)
 include(CheckTypeSize)

--- a/lib/default.sh
+++ b/lib/default.sh
@@ -21,6 +21,7 @@ ABUSECMAKEBUILD=yes		# Use cmake build for cmake* ABTYPEs?
 ABSPLITDBG=yes			# Automatically compile with -g and produce debug symbol package ($PKGNAME-dbg)?
 ABBUILDDEPONLY=no		# Avoid installing runtime dependencies when building?
 ABPATCHLAX=no			# Disallow fuzzy patching
+ABSPIRAL=yes			# Enable spiral provides generation
 
 # Strict Autotools option checking?
 AUTOTOOLS_STRICT=yes

--- a/native/abnativeelf.cpp
+++ b/native/abnativeelf.cpp
@@ -743,9 +743,6 @@ int elf_copy_debug_symbols_parallel(const std::vector<std::string> &directories,
 
   pool.wait_for_completion();
 
-  if (pool.has_error())
-    return 1;
-
   if (flags & AB_ELF_FIND_SO_DEPS) {
     const auto pool_results = pool.get_sodeps();
     so_deps.insert(pool_results.begin(), pool_results.end());
@@ -755,6 +752,9 @@ int elf_copy_debug_symbols_parallel(const std::vector<std::string> &directories,
     const auto spiral_results = pool.get_spiral_provides();
     spiral_provides.insert(spiral_results.begin(), spiral_results.end());
   }
+
+  if (pool.has_error())
+    return 1;
 
   return 0;
 }

--- a/native/abnativeelf.cpp
+++ b/native/abnativeelf.cpp
@@ -578,8 +578,18 @@ int elf_copy_debug_symbols(const char *src_path, const char *dst_path,
   const char *data = static_cast<const char *>(file.addr());
   const ELFParseResult result = identify_binary_data(data, size);
 
-  if (flags & AB_ELF_GENERATE_SPIRAL_PROVIDES) {
-    const std::string filename(basename(src_path));
+  constexpr const char *base_path = "/usr/lib/";
+  constexpr const size_t base_len = sizeof(base_path);
+
+  const std::string filename(basename(src_path));
+  const size_t filename_len = filename.size();
+  const size_t src_len = strlen(src_path);
+  bool in_usr_lib = false;
+  if (src_len >= (base_len + filename_len)) {
+    const int src_offset = src_len - base_len - filename_len - 1;
+    in_usr_lib = (memcmp(src_path + src_offset, base_path, base_len) == 0);
+  }
+  if ((flags & AB_ELF_GENERATE_SPIRAL_PROVIDES) && in_usr_lib) {
     to_spiral_provides(filename, spiral_provides);
 
     if ((! result.soname.empty()) && (result.soname != filename)) {

--- a/native/abnativeelf.cpp
+++ b/native/abnativeelf.cpp
@@ -492,15 +492,14 @@ static inline int forked_execvp(const char *path, char *const argv[]) {
   return status;
 }
 
-std::vector<std::string>
-to_spiral_provides(const std::string &soname) {
-  std::vector<std::string> ret;
-
-  if (soname.empty()) return ret;
+void
+to_spiral_provides(const std::string &soname,
+                   GuardedSet<std::string> &spiral_provides) {
+  if (soname.empty()) return;
 
   // Rule out strings without the ".so" extension name
   const size_t libname_pos = soname.find(".so");
-  if (libname_pos == std::string::npos) return ret;
+  if (libname_pos == std::string::npos) return;
 
   // Extract libname
   auto libname = soname.substr(0, libname_pos);
@@ -517,7 +516,7 @@ to_spiral_provides(const std::string &soname) {
 
     // Contains invalid character
     if ((c < 'a') || (c > 'z')) {
-      return ret;
+      return;
     }
   }
 
@@ -530,16 +529,16 @@ to_spiral_provides(const std::string &soname) {
   const size_t sover_start = libname_pos + 3;
   // If there's no sover
   if (sover_start == soname.size()) {
-    ret.emplace_back(libname);
-    ret.emplace_back(fmt::format("{}-dev", libname));
-    return ret;
+    spiral_provides.emplace(dev_name);
+    spiral_provides.emplace(libname);
+    return;
   }
   // Make sure there's the dot
-  if (soname[sover_start] != '.') return ret;
+  if (soname[sover_start] != '.') return;
   size_t sover_major = 0;
   for (const auto &c : soname.substr(sover_start + 1, soname.size())) {
     if (c == '.') break;
-    if ((c < '0') || c > '9') return ret;
+    if ((c < '0') || c > '9') return;
     sover_major *= 10;
     sover_major += c - '0';
   }
@@ -547,15 +546,13 @@ to_spiral_provides(const std::string &soname) {
   // Add a '-' in between libname and sover if libname ends with a digit
   char libname_last = libname[libname.size() - 1];
   if ((libname_last >= '0') && (libname_last <= '9')) {
-    ret.emplace_back(fmt::format("{}-{}", libname, sover_major));
+    spiral_provides.emplace(fmt::format("{}-{}", libname, sover_major));
   } else {
-    ret.emplace_back(fmt::format("{}{}", libname, sover_major));
+    spiral_provides.emplace(fmt::format("{}{}", libname, sover_major));
   }
 
   // Add -dev package name
-  ret.emplace_back(fmt::format("{}-dev", libname));
-
-  return ret;
+  spiral_provides.emplace(dev_name);
 }
 
 int elf_copy_debug_symbols(const char *src_path, const char *dst_path,
@@ -583,12 +580,10 @@ int elf_copy_debug_symbols(const char *src_path, const char *dst_path,
 
   if (flags & AB_ELF_GENERATE_SPIRAL_PROVIDES) {
     const std::string filename(basename(src_path));
-    const auto spiral_filename = to_spiral_provides(filename);
-    spiral_provides.insert(spiral_filename.begin(), spiral_filename.end());
+    to_spiral_provides(filename, spiral_provides);
 
-    if (! result.soname.empty()) {
-      const auto spiral_soname = to_spiral_provides(result.soname);
-      spiral_provides.insert(spiral_soname.begin(), spiral_soname.end());
+    if ((! result.soname.empty()) && (result.soname != filename)) {
+      to_spiral_provides(result.soname, spiral_provides);
     }
   }
 

--- a/native/abnativeelf.hpp
+++ b/native/abnativeelf.hpp
@@ -44,12 +44,15 @@ constexpr int AB_ELF_USE_EU_STRIP = 1 << 1;
 constexpr int AB_ELF_FIND_SO_DEPS = 1 << 2;
 constexpr int AB_ELF_CHECK_ONLY = 1 << 3;
 constexpr int AB_ELF_SAVE_WITH_PATH = 1 << 4;
+constexpr int AB_ELF_GENERATE_SPIRAL_PROVIDES = 1 << 5;
 
 int elf_copy_to_symdir(const char *src_path, const char *dst_path,
                        const char *build_id);
 int elf_copy_debug_symbols(const char *src_path, const char *dst_path,
-                           int flags, GuardedSet<std::string> &symbols);
+                           int flags, GuardedSet<std::string> &symbols,
+                           GuardedSet<std::string> &spiral_provides);
 int elf_copy_debug_symbols_parallel(const std::vector<std::string> &directories,
                                     const char *dst_path,
                                     std::unordered_set<std::string> &so_deps,
+                                    std::unordered_set<std::string> &spiral_provides,
                                     int flags = AB_ELF_USE_EU_STRIP);

--- a/native/abnativeelf.hpp
+++ b/native/abnativeelf.hpp
@@ -19,6 +19,7 @@ enum class BinaryType : uint8_t {
 struct ELFParseResult {
   std::vector<const char *> needed_libs;
   std::string build_id;
+  std::string soname;
   BinaryType bin_type;
   bool has_debug_info;
 };

--- a/native/abnativeelf.hpp
+++ b/native/abnativeelf.hpp
@@ -32,6 +32,10 @@ public:
     auto lock_guard = std::lock_guard<std::mutex>{m_mutex};
     m_set.insert(begin, end);
   }
+  void emplace(T elem) {
+    auto lock_guard = std::lock_guard<std::mutex>{m_mutex};
+    m_set.emplace(std::move(elem));
+  }
   const std::unordered_set<T> &get_set() const { return m_set; }
 
 private:

--- a/native/abnativefunctions.cpp
+++ b/native/abnativefunctions.cpp
@@ -807,11 +807,21 @@ static int abelf_copy_dbg(WORD_LIST *list) {
   if (!dst)
     return EX_BADUSAGE;
   GuardedSet<std::string> symbols{};
+  GuardedSet<std::string> spiral_provides;
   const int ret =
-      elf_copy_debug_symbols(src, dst, flags, symbols);
+      elf_copy_debug_symbols(src, dst, flags, symbols, spiral_provides);
   if (ret < 0)
     return 10;
   return 0;
+}
+
+static void ab_set_to_bash_array(const char *varname, const std::unordered_set<std::string> &set) {
+  auto *var = make_new_array_variable(const_cast<char *>(varname));
+  var->attributes |= att_readonly;
+  auto *var_a = array_cell(var);
+  for (const auto &elem : set) {
+    array_push(var_a, const_cast<char *>(elem.c_str()));
+  }
 }
 
 /**
@@ -825,8 +835,9 @@ static int abelf_copy_dbg(WORD_LIST *list) {
  *      10  - error occurred during processing
  */
 static int abelf_copy_dbg_parallel(WORD_LIST *list) {
-  constexpr const char *varname = "__AB_SO_DEPS";
-  int flags = AB_ELF_FIND_SO_DEPS;
+  constexpr const char *varname_so_deps = "__AB_SO_DEPS";
+  constexpr const char *varname_spiral = "__AB_SPIRAL_PROVIDES";
+  int flags = AB_ELF_FIND_SO_DEPS | AB_ELF_GENERATE_SPIRAL_PROVIDES;
 
   reset_internal_getopt();
   int opt = 0;
@@ -855,17 +866,14 @@ static int abelf_copy_dbg_parallel(WORD_LIST *list) {
   const auto dst = std::string{args.back()};
   args.pop_back();
   std::unordered_set<std::string> so_deps{};
+  std::unordered_set<std::string> spiral_provides;
   const int ret =
-      elf_copy_debug_symbols_parallel(args, dst.c_str(), so_deps, flags);
+      elf_copy_debug_symbols_parallel(args, dst.c_str(), so_deps, spiral_provides, flags);
   if (ret < 0)
     return 10;
   // copy the data to the bash variable
-  auto *var = make_new_array_variable(const_cast<char *>(varname));
-  var->attributes |= att_readonly;
-  auto *var_a = array_cell(var);
-  for (const auto &so_dep : so_deps) {
-    array_push(var_a, const_cast<char *>(so_dep.c_str()));
-  }
+  ab_set_to_bash_array(varname_so_deps, so_deps);
+  ab_set_to_bash_array(varname_spiral, spiral_provides);
   return 0;
 }
 

--- a/pm/dpkg.sh
+++ b/pm/dpkg.sh
@@ -57,11 +57,46 @@ dpkgfield() {
 			done <<< "${_data}"
 		fi
 		if [ "${_v}" = "@AB_SPIRAL_PROVIDES@" ]; then
-			if ! ((${#__AB_SPIRAL_PROVIDES})); then
-				abdbg "No Debian-compatible provides generated" >&2
-				continue
+			if [ -d "$PKGDIR"/usr/lib/girepository-1.0 ]; then
+				for gir in `find "$PKGDIR"/usr/lib/girepository-1.0/ -type f`; do
+					_string_v+=("$(echo gir1.2-$(basename $gir) | \
+						sed -e 's|.typelib$||g' | \
+						tr '[:upper:]' '[:lower:]')")
+				done
 			fi
-			abdbg "Generated Debian-compatible (Spiral) provides: ${__AB_SPIRAL_PROVIDES[@]}" >&2
+			if [ -d "$PKGDIR"/usr/lib/python"$ABPY2VER"/site-packages ]; then
+				for py2mod in `find "$PKGDIR"/usr/lib/python"$ABPY2VER"/site-packages -mindepth 1 -maxdepth 1 -type d`; do
+					_string_v+=("$(echo python${ABPY2VER:0:1}-$(basename $py2mod | cut -f1 -d'-') | \
+						sort -u | \
+						sed -e 's|_|-|g' | \
+						tr '[:upper:]' '[:lower:]')")
+				done
+				for py2mod in `find "$PKGDIR"/usr/lib/python"$ABPY2VER"/site-packages -mindepth 1 -maxdepth 1 -type f -name '*.py'`; do
+					_string_v+=("$(echo python${ABPY2VER:0:1}-$(basename $py2mod | cut -f1 -d'.') | \
+						sort -u | \
+						sed -e 's|_|-|g' | \
+						tr '[:upper:]' '[:lower:]')")
+				done
+			fi
+			if [ -d "$PKGDIR"/usr/lib/python"$ABPY3VER"/site-packages ]; then
+				for py3mod in `find "$PKGDIR"/usr/lib/python"$ABPY3VER"/site-packages -mindepth 1 -maxdepth 1 -type d`; do
+					_string_v+=("$(echo python${ABPY3VER:0:1}-$(basename $py3mod | cut -f1 -d'-') | \
+						sort -u | \
+						sed -e 's|_|-|g' | \
+						tr '[:upper:]' '[:lower:]')")
+				done
+				for py3mod in `find "$PKGDIR"/usr/lib/python"$ABPY3VER"/site-packages -mindepth 1 -maxdepth 1 -type f -name '*.py'`; do
+					_string_v+=("$(echo python${ABPY3VER:0:1}-$(basename $py3mod | cut -f1 -d'.') | \
+						sort -u | \
+						sed -e 's|_|-|g' | \
+						tr '[:upper:]' '[:lower:]')")
+				done
+			fi
+			for SPIRAL_PROV in "${__AB_SPIRAL_PROVIDES[@]}"; do
+				_string_v+=("${SPIRAL_PROV}")
+			done
+			abdbg "Generated Debian-compatible (Spiral) provides: ${_string_v[@]/@AB_SPIRAL_PROVIDES@/}" >&2
+			# FIXME: Duplicate for loop to make the above abdbg() pretty, anyway to make it more elegant?
 			for SPIRAL_PROV in "${__AB_SPIRAL_PROVIDES[@]}"; do
 				# Add `_spiral` marker for generated provides
 				_string_v+=("${SPIRAL_PROV}_spiral")

--- a/pm/dpkg.sh
+++ b/pm/dpkg.sh
@@ -91,7 +91,8 @@ dpkgfield() {
 			_buffer+=("$(abpm_debver "${_v}>=$(dpkg_getver "${_v}")")")
 		fi
 	done
-	echo "$1: $(ab_join_elements _buffer $', ')"
+	local _content="$(ab_join_elements _buffer $', ')"
+	[ "${_content}" ] && echo "$1: ${_content}"
 }
 
 dpkgctrl() {
@@ -110,24 +111,24 @@ dpkgctrl() {
 		echo "Essential: no"
 	fi
 
-	[ "$PKGDEP" ] && dpkgfield Depends "$PKGDEP"
-	[ "$PKGPRDEP" ] && dpkgfield Pre-Depends "$PKGPRDEP"
+	dpkgfield Depends "$PKGDEP"
+	dpkgfield Pre-Depends "$PKGPRDEP"
 	VER_NONE=1 # We don't autofill versions in optional fields
-	[ "$PKGRECOM" ] && dpkgfield Recommends "$PKGRECOM"
-	[ "$PKGREP" ] && dpkgfield Replaces "$PKGREP"
-	[ "$PKGCONFL" ] && dpkgfield Conflicts "$PKGCONFL"
+	dpkgfield Recommends "$PKGRECOM"
+	dpkgfield Replaces "$PKGREP"
+	dpkgfield Conflicts "$PKGCONFL"
 
 	if bool "$ABSPIRAL"; then
 		PKGPROV+=" @AB_SPIRAL_PROVIDES@"
 	fi
-	[ "$PKGPROV" ] && VER_NONE=1 dpkgfield Provides "$PKGPROV"
+	dpkgfield Provides "$PKGPROV"
 
-	[ "$PKGSUG" ] && dpkgfield Suggests "$PKGSUG"
+	dpkgfield Suggests "$PKGSUG"
 	local _pkgbreak
 	_pkgbreak="$(ab_get_item_by_key __ABMODIFIERS PKGBREAK 1)"
 	if [ "${_pkgbreak}" = '0' ]; then
 		abwarn 'Not emitting PKGBREAK due to modifiers' >&2
-	elif [ "$PKGBREAK" ]; then
+	else
 		dpkgfield Breaks "$PKGBREAK"
 	fi
 	if [ -e "$SRCDIR"/autobuild/extra-dpkg-control ]; then

--- a/pm/dpkg.sh
+++ b/pm/dpkg.sh
@@ -116,7 +116,12 @@ dpkgctrl() {
 	[ "$PKGRECOM" ] && dpkgfield Recommends "$PKGRECOM"
 	[ "$PKGREP" ] && dpkgfield Replaces "$PKGREP"
 	[ "$PKGCONFL" ] && dpkgfield Conflicts "$PKGCONFL"
+
+	if bool "$ABSPIRAL"; then
+		PKGPROV+=" @AB_SPIRAL_PROVIDES@"
+	fi
 	[ "$PKGPROV" ] && VER_NONE=1 dpkgfield Provides "$PKGPROV"
+
 	[ "$PKGSUG" ] && dpkgfield Suggests "$PKGSUG"
 	local _pkgbreak
 	_pkgbreak="$(ab_get_item_by_key __ABMODIFIERS PKGBREAK 1)"

--- a/pm/dpkg.sh
+++ b/pm/dpkg.sh
@@ -58,10 +58,10 @@ dpkgfield() {
 		fi
 		if [ "${_v}" = "@AB_SPIRAL_PROVIDES@" ]; then
 			if ! ((${#__AB_SPIRAL_PROVIDES})); then
-				abdbg "No spiral provides generated" >&2
+				abdbg "No Debian-compatible provides generated" >&2
 				continue
 			fi
-			abdbg "Generated spiral provides: ${__AB_SPIRAL_PROVIDES[@]}" >&2
+			abdbg "Generated Debian-compatible (Spiral) provides: ${__AB_SPIRAL_PROVIDES[@]}" >&2
 			for SPIRAL_PROV in "${__AB_SPIRAL_PROVIDES[@]}"; do
 				# Add `_spiral` marker for generated provides
 				_string_v+=("${SPIRAL_PROV}_spiral")

--- a/pm/dpkg.sh
+++ b/pm/dpkg.sh
@@ -84,7 +84,7 @@ dpkgfield() {
 			_buffer+=("$(abpm_debver "${_v}")")
 		elif [[ "${_v}" =~ _spiral$ ]]; then
 			# Remove _spiral marker, append version
-			_buffer+=("$(abpm_debver "${_v%_spiral}==0:${_ver#*:}")")
+			_buffer+=("$(abpm_debver "${_v%_spiral}==${PKGEPOCH_SPIRAL:-0}:${_ver#*:}")")
 		elif ((VER_NONE)) || [[ "$_v" =~ _$ ]]; then
 			_buffer+=("${_v%_}");
 		else

--- a/sets/exports.json
+++ b/sets/exports.json
@@ -20,7 +20,8 @@
     "ABMPM",
     "ABAPMS",
     "BUILDDEP",
-    "PKGPRDEP"
+    "PKGPRDEP",
+    "PKGEPOCH_SPIRAL"
   ],
   "filter_elf": ["ABSTRIP", "ABSPLITDBG", "SYMTAB"],
   "flags": [


### PR DESCRIPTION
This pull request merges a preliminary implementation of Spiral, Debian-compatible dependency marker for AOSC OS. This implementation currently supports marking the following:

- soname support (imprecise, uses a simple rule logic)
- GObject-Introspection typelibs (`gir1.2-*`)
- Python modules (`python{2,3}-*`)