### PR TITLE
templates/autotools: make AUTOTOOLS_OPTION_CHECKING an array

### DIFF
--- a/templates/10-autotools.sh
+++ b/templates/10-autotools.sh
@@ -81,7 +81,7 @@ build_autotools_configure() {
 	$ABCONFWRAPPER \
 	${configure:="$SRCDIR"/configure} \
 			"${AUTOTOOLS_TARGET[@]}" "${AUTOTOOLS_DEF[@]}" "${AUTOTOOLS_AFTER[@]}" \
-			"$AUTOTOOLS_OPTION_CHECKING" \
+			"${AUTOTOOLS_OPTION_CHECKING[@]}" \
 			|| abdie "Failed to run configure: $?."
 }
 


### PR DESCRIPTION
This PR does the following thing:
- Treat `AUTOTOOLS_OPTION_CHECKING` as an array.

This allows bash to avoid generating `''` as an argument to `./configure` when
`AUTOTOOLS_OPTION_CHECKING` is empty.