### PR TITLE
arch/optenv32: disable Spiral generation

### DIFF
--- a/arch/optenv32.sh
+++ b/arch/optenv32.sh
@@ -27,6 +27,9 @@ export PATH="$BINDIR:$PATH"
 # linux32 tricks the build system.
 export ABCONFWRAPPER="linux32"
 
+# Disable Spiral provides geenration.
+ABSPIRAL=0
+
 CFLAGS_COMMON_ARCH=('-fomit-frame-pointer' '-march=x86-64' '-mtune=sandybridge' '-msse2' '-m32')
 
 export PKG_CONFIG_DIR=/opt/32/lib/pkgconfig


### PR DESCRIPTION
This PR disables the generation of Spiral related content for optenv targets, since they are not used.