### PR TITLE
[RFC] arch/amd64: let the frame pointer return

### DIFF
--- a/arch/_common.sh
+++ b/arch/_common.sh
@@ -4,7 +4,7 @@
 
 # C Compiler Flags.
 CFLAGS_COMMON=('-pipe' '-Wno-error')
-CFLAGS_COMMON_OPTI=('-O2')
+CFLAGS_COMMON_OPTI=('-O2' '-fno-omit-frame-pointer' '-mno-omit-leaf-frame-pointer')
 CFLAGS_COMMON_DEBUG=('-O0')	# not that frequently used since autotools know it.
 CFLAGS_GCC=()
 CFLAGS_GCC_OPTI=('-fira-loop-pressure' '-fira-hoist-pressure' '-ftree-vectorize')
@@ -28,7 +28,7 @@ OBJCXXFLAGS_COMMON_WEIRD=()
 OBJCXXFLAGS_COMMON_PERMISSIVE=('-fpermissive')
 # RUST Flags.
 RUSTFLAGS_COMMON=()
-RUSTFLAGS_COMMON_OPTI=('-Ccodegen-units=1' '-Copt-level=3' '-Cdebuginfo=line-tables-only')
+RUSTFLAGS_COMMON_OPTI=('-Ccodegen-units=1' '-Copt-level=3' '-Cdebuginfo=line-tables-only' '-Cforce-frame-pointers=yes')
 RUSTFLAGS_COMMON_WEIRD=()
 # Use clang + lld for processing LTO
 RUSTFLAGS_COMMON_OPTI_LTO=(

--- a/arch/amd64.sh
+++ b/arch/amd64.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 ##arch/amd64.sh: Build definitions for amd64.
 ##@copyright GPL-2.0+
-CFLAGS_COMMON_ARCH=('-fomit-frame-pointer' '-march=x86-64' '-mtune=sandybridge' '-msse2')
+CFLAGS_COMMON_ARCH=('-march=x86-64' '-mtune=sandybridge' '-msse2')
 RUSTFLAGS_COMMON_ARCH=('-Ctarget-cpu=x86-64')


### PR DESCRIPTION
https://www.brendangregg.com/blog/2024-03-17/the-return-of-the-frame-pointers.html argues that amd64 has enough registers to not be bothered by the FP. Google, Meta, Fedora, Ubuntu, and Arch seem to agree.

Should we follow suit? The main justification is that the FP gives real-time profiling tools a proper view of the stack.