### PR TITLE
default-flags: specify runtime data path for autotools

### DIFF
--- a/lib/default-flags.sh
+++ b/lib/default-flags.sh
@@ -11,6 +11,7 @@ AUTOTOOLS_DEF=(
 	--bindir="$BINDIR"
 	--sbindir="$BINDIR"
 	--mandir="$MANDIR"
+	--runstatedir="$RUNDIR"
 )
 CMAKE_DEF=(
 	-DCMAKE_INSTALL_PREFIX="$PREFIX"


### PR DESCRIPTION
This PR adds additional arguments for Autotools, which specifies the runtime data path to /run, to avoid files to be written to the non-standard path /var/run.