### PR TITLE
[Core 12] arch/amd64: let the frame pointer return

### DIFF
--- a/arch/_common.sh
+++ b/arch/_common.sh
@@ -7,7 +7,7 @@ HAS_HWCAPS=0
 
 # C Compiler Flags.
 CFLAGS_COMMON=('-pipe' '-Wno-error')
-CFLAGS_COMMON_OPTI=('-O2')
+CFLAGS_COMMON_OPTI=('-O2' '-fno-omit-frame-pointer' '-mno-omit-leaf-frame-pointer')
 CFLAGS_COMMON_DEBUG=('-O0')	# not that frequently used since autotools know it.
 CFLAGS_GCC=()
 CFLAGS_GCC_OPTI=('-fira-loop-pressure' '-fira-hoist-pressure' '-ftree-vectorize')
@@ -31,7 +31,7 @@ OBJCXXFLAGS_COMMON_WEIRD=()
 OBJCXXFLAGS_COMMON_PERMISSIVE=('-fpermissive')
 # RUST Flags.
 RUSTFLAGS_COMMON=()
-RUSTFLAGS_COMMON_OPTI=('-Ccodegen-units=1' '-Copt-level=3' '-Cdebuginfo=line-tables-only')
+RUSTFLAGS_COMMON_OPTI=('-Ccodegen-units=1' '-Copt-level=3' '-Cdebuginfo=line-tables-only' '-Cforce-frame-pointers=yes')
 RUSTFLAGS_COMMON_WEIRD=()
 # Use clang + lld for processing LTO
 RUSTFLAGS_COMMON_OPTI_LTO=(

--- a/arch/amd64.sh
+++ b/arch/amd64.sh
@@ -6,9 +6,6 @@
 HAS_HWCAPS=1
 HWCAPS=('x86-64-v2' 'x86-64-v3' 'x86-64-v4')
 
-# CFLAGS without -march and μarch specific tuning.
-CFLAGS_COMMON_ARCH_BASE=('-fomit-frame-pointer')
-
 # Default -march and μarch specific tuning.
 # No need to reference CFLAGS_COMMON_ARCH_BASE, it will be concatenated.
 CFLAGS_COMMON_ARCH=('-march=x86-64' '-mtune=sandybridge' '-msse2')

--- a/arch/amd64_avx+.sh
+++ b/arch/amd64_avx+.sh
@@ -2,5 +2,5 @@
 ##arch/amd64_avx.sh: Build definitions for amd64 with AVX support.
 ##                   Intel SandyBridge and AMD Bulldozer or later processors.
 ##@copyright GPL-2.0+
-CFLAGS_COMMON_ARCH=('-fomit-frame-pointer' '-march=sandybridge')
+CFLAGS_COMMON_ARCH=('-march=sandybridge')
 RUSTFLAGS_COMMON_ARCH=('-Ctarget-cpu=sandybridge')

--- a/arch/amd64_avx2+.sh
+++ b/arch/amd64_avx2+.sh
@@ -2,5 +2,5 @@
 ##arch/amd64_avx2.sh: Build definitions for amd64 with AVX2 support.
 ##                    Intel Haswell+, AMD bdver4+, VIA eden-x4+.
 ##@copyright GPL-2.0+
-CFLAGS_COMMON_ARCH=('-fomit-frame-pointer' '-march=haswell' '-mno-rdrnd')
+CFLAGS_COMMON_ARCH=('-march=haswell' '-mno-rdrnd')
 RUSTFLAGS_COMMON_ARCH=('-Ctarget-cpu=haswell' '-Ctarget-feature=-rdrnd')


### PR DESCRIPTION
Apologies for abruptly reverting that change but this change is best queued for Core 12 when we survey potential changes for core toolchains. cc @Artoria2e5  @jiegec 

From original pull request:

> https://www.brendangregg.com/blog/2024-03-17/the-return-of-the-frame-pointers.html argues that amd64 has enough registers to not be bothered by the FP. Google, Meta, Fedora, Ubuntu, and Arch seem to agree.
>
> Should we follow suit? The main justification is that the FP gives real-time profiling tools a proper view of the stack.
