### PR TITLE
Change default CFLAGS for i486 target

### DIFF
--- a/arch/i486.sh
+++ b/arch/i486.sh
@@ -3,11 +3,11 @@
 ##@copyright GPL-2.0+
 
 # Retro: Overriding mainline definitions, and take more interest in reducing code size.
-CFLAGS_COMMON_OPTI=('-Os' '-ffunction-sections' '-fdata-sections')
+CFLAGS_COMMON_OPTI=('-O2' '-fno-tree-ch' '-ffunction-sections' '-fdata-sections')
 LDFLAGS_COMMON_OPTI=('-Wl,--gc-sections')
 # Retro: Also disabling -ftree-vectorization which could potentially enlarge code size.
 CFLAGS_GCC_OPTI=('-fira-loop-pressure' '-fira-hoist-pressure')
 
-CFLAGS_COMMON_ARCH=('-march=i486' '-mtune=bonnell')
+CFLAGS_COMMON_ARCH=('-march=i486' '-mtune=generic')
 
 RUSTFLAGS_COMMON_ARCH=('-Ctarget-cpu=i486' '-Clink-args=-latomic')

--- a/arch/sparc64.sh
+++ b/arch/sparc64.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-##arch/sparc64.sh: Build definitions for i486.
+##arch/sparc64.sh: Build definitions for sparc64.
 ##@copyright GPL-2.0+
 
 # Retro: Overriding mainline definitions, and take more interest in reducing code size.


### PR DESCRIPTION
-O2 -fno-tree-ch generates better results than -Os when keeping binary size small, especially on architectures with severe penalties for non-aligned load/store, and/or architectures with rather small L2/L3 caches.
Also Glibc might be miscompiled by -Os switch, so I suggest using -O2 instead of -Os on selected packages.
See [https://github.com/openwrt/openwrt/commit/bf604f35035ae49a3db8a1e1ff67f512a0de86bd](url)

-mtune=bonnell is suboptimal for any CPU other than first generation Intel Atom processors, and will increase binary size.
https://github.com/AOSC-Dev/aosc-os-abbs/pull/7406
With this patch GCC should generate very promising results for Intel P6 variants / AMD K7 Athlons .

Fixes a typo in sparc64 too.