### PR TITLE
Core 12: HWCAPS helpers

### DIFF
--- a/arch/_common.sh
+++ b/arch/_common.sh
@@ -2,6 +2,9 @@
 ##arch/_common.sh: Common arch defs for all ab arches, defines-mutable.
 ##@copyright GPL-2.0+
 
+# HWCAPS is not supported on most targets.
+HAS_HWCAPS=0
+
 # C Compiler Flags.
 CFLAGS_COMMON=('-pipe' '-Wno-error')
 CFLAGS_COMMON_OPTI=('-O2')

--- a/arch/amd64.sh
+++ b/arch/amd64.sh
@@ -1,5 +1,22 @@
 #!/bin/bash
 ##arch/amd64.sh: Build definitions for amd64.
 ##@copyright GPL-2.0+
-CFLAGS_COMMON_ARCH=('-fomit-frame-pointer' '-march=x86-64' '-mtune=sandybridge' '-msse2')
+
+# This architecture has glibc HWCAPS support.
+HAS_HWCAPS=1
+HWCAPS=('x86-64-v2' 'x86-64-v3' 'x86-64-v4')
+
+# CFLAGS without -march and μarch specific tuning.
+CFLAGS_COMMON_ARCH_BASE=('-fomit-frame-pointer')
+
+# Default -march and μarch specific tuning.
+# No need to reference CFLAGS_COMMON_ARCH_BASE, it will be concatenated.
+CFLAGS_COMMON_ARCH=('-march=x86-64' '-mtune=sandybridge' '-msse2')
+
+# TODO What about Rust libraries?
 RUSTFLAGS_COMMON_ARCH=('-Ctarget-cpu=x86-64')
+
+CFLAGS_HWCAPS_x86_64_v2=("${CFLAGS_COMMON_ARCH_BASE[@]}" "-march=x86-64-v2" "-mtune=sandybridge" "-msse2" "-msse4.2")
+CFLAGS_HWCAPS_x86_64_v3=("${CFLAGS_COMMON_ARCH_BASE[@]}" "-march=x86-64-v3" "-mtune=haswell" "-msse2" "-msse4.2" "-mavx2")
+# TBD: Which -mtune to be chosen for x86_64 v4?
+CFLAGS_HWCAPS_x86_64_v4=("${CFLAGS_COMMON_ARCH_BASE[@]}" "-march=x86-64-v4" "-mtune=generic" "-msse2" "-msse4.2" "-mavx2" "-mavx512f" "-mavx512bw" "-mavx512cd" "-mavx512dq" "-mavx512vl")

--- a/arch/amd64.sh
+++ b/arch/amd64.sh
@@ -12,15 +12,27 @@ CFLAGS_COMMON_ARCH_BASE=('-fomit-frame-pointer')
 # Default -march and μarch specific tuning.
 # No need to reference CFLAGS_COMMON_ARCH_BASE, it will be concatenated.
 CFLAGS_COMMON_ARCH=('-march=x86-64' '-mtune=sandybridge' '-msse2')
-
-# TODO What about Rust libraries?
 RUSTFLAGS_COMMON_ARCH=('-Ctarget-cpu=x86-64')
 
-CFLAGS_HWCAPS_x86_64_v2=("${CFLAGS_COMMON_ARCH_BASE[@]}" "-march=x86-64-v2" "-mtune=sandybridge" "-msse2" "-msse4.2")
-CFLAGS_HWCAPS_x86_64_v3=("${CFLAGS_COMMON_ARCH_BASE[@]}" "-march=x86-64-v3" "-mtune=haswell" "-msse2" "-msse4.2" "-mavx2")
+# List of HWCAPS subtargets in x86-64:
+#
+# - x86-64-v2: CPUs with CMPXCHG16B, SSE3, SSSE3 and SSE4.2 extensions,
+#   starting from Sandy Bridge.
+# - x86-64-v3: CPUs with AVX, AVX2, BMI1, BMI2, and other miscellaneous
+#   instructions, staring from Haswell. Also the most common one.
+# - x86-64-v4: CPUs with AVX512 (AVX-512-F, AVX-512-BW, AVX-512-CD,
+#   AVX-512-DQ and AVX-512-DL specifically). Few consumer-grade CPUs
+#   supports this.
+CFLAGS_HWCAPS_x86_64_v2=("${CFLAGS_COMMON_ARCH_BASE[@]}" "-march=x86-64-v2" "-mtune=sandybridge" "-msse2" "-msse3" "-mssse3" "-msse4.2")
+CFLAGS_HWCAPS_x86_64_v3=("${CFLAGS_COMMON_ARCH_BASE[@]}" "-march=x86-64-v3" "-mtune=haswell" "-msse2" "-msse3" "-mssse3" "-msse4.2" "-mavx" "-mavx2")
 # TBD: Which -mtune to be chosen for x86_64 v4?
-CFLAGS_HWCAPS_x86_64_v4=("${CFLAGS_COMMON_ARCH_BASE[@]}" "-march=x86-64-v4" "-mtune=generic" "-msse2" "-msse4.2" "-mavx2" "-mavx512f" "-mavx512bw" "-mavx512cd" "-mavx512dq" "-mavx512vl")
+CFLAGS_HWCAPS_x86_64_v4=("${CFLAGS_COMMON_ARCH_BASE[@]}" "-march=x86-64-v4" "-mtune=generic" "-msse2" "-msse3" "-mssse3" "-msse4.2" "-mavx" "-mavx2" "-mavx512f" "-mavx512bw" "-mavx512cd" "-mavx512dq" "-mavx512vl")
 
 RUSTFLAGS_HWCAPS_x86_64_v2=("-Ctarget-cpu=x86-64-v2")
 RUSTFLAGS_HWCAPS_x86_64_v3=("-Ctarget-cpu=x86-64-v3")
 RUSTFLAGS_HWCAPS_x86_64_v4=("-Ctarget-cpu=x86-64-v4")
+
+# CPPFLAGS must be set for function selection in preprocessing to work.
+CPPFLAGS_HWCAPS_x86_64_v2=("-march=x86-64-v2" "-msse2" "-msse3" "-mssse3" "-msse4.2")
+CPPFLAGS_HWCAPS_x86_64_v3=("-march=x86-64-v3" "-msse2" "-msse3" "-mssse3" "-msse4.2" "-mavx2")
+CPPFLAGS_HWCAPS_x86_64_v4=("-march=x86-64-v4" "-msse2" "-msse3" "-mssse3" "-msse4.2" "-mavx2" "-mavx512f" "-mavx512bw" "-mavx512cd" "-mavx512dq" "-mavx512vl")

--- a/arch/amd64.sh
+++ b/arch/amd64.sh
@@ -20,3 +20,7 @@ CFLAGS_HWCAPS_x86_64_v2=("${CFLAGS_COMMON_ARCH_BASE[@]}" "-march=x86-64-v2" "-mt
 CFLAGS_HWCAPS_x86_64_v3=("${CFLAGS_COMMON_ARCH_BASE[@]}" "-march=x86-64-v3" "-mtune=haswell" "-msse2" "-msse4.2" "-mavx2")
 # TBD: Which -mtune to be chosen for x86_64 v4?
 CFLAGS_HWCAPS_x86_64_v4=("${CFLAGS_COMMON_ARCH_BASE[@]}" "-march=x86-64-v4" "-mtune=generic" "-msse2" "-msse4.2" "-mavx2" "-mavx512f" "-mavx512bw" "-mavx512cd" "-mavx512dq" "-mavx512vl")
+
+RUSTFLAGS_HWCAPS_x86_64_v2=("-Ctarget-cpu=x86-64-v2")
+RUSTFLAGS_HWCAPS_x86_64_v3=("-Ctarget-cpu=x86-64-v3")
+RUSTFLAGS_HWCAPS_x86_64_v4=("-Ctarget-cpu=x86-64-v4")

--- a/arch/amd64.sh
+++ b/arch/amd64.sh
@@ -14,6 +14,12 @@ CFLAGS_COMMON_ARCH_BASE=('-fomit-frame-pointer')
 CFLAGS_COMMON_ARCH=('-march=x86-64' '-mtune=sandybridge' '-msse2')
 RUSTFLAGS_COMMON_ARCH=('-Ctarget-cpu=x86-64')
 
+# HWCAPS subtargets in x86-64 are based on the microarchitecture levels
+# defined in the x86-64 psABI[1]. As the base level, x86-64-v1 does not
+# act as a HWCAPS subtarget.
+#
+# [1]: https://gitlab.com/x86-psABIs/x86-64-ABI/-/commit/77566eb03bc6a326811cb7e9a6b9396884b67c7c
+
 # List of HWCAPS subtargets in x86-64:
 #
 # - x86-64-v2: CPUs with CMPXCHG16B, SSE3, SSSE3 and SSE4.2 extensions,
@@ -23,16 +29,15 @@ RUSTFLAGS_COMMON_ARCH=('-Ctarget-cpu=x86-64')
 # - x86-64-v4: CPUs with AVX512 (AVX-512-F, AVX-512-BW, AVX-512-CD,
 #   AVX-512-DQ and AVX-512-DL specifically). Few consumer-grade CPUs
 #   supports this.
-CFLAGS_HWCAPS_x86_64_v2=("${CFLAGS_COMMON_ARCH_BASE[@]}" "-march=x86-64-v2" "-mtune=sandybridge" "-msse2" "-msse3" "-mssse3" "-msse4.2")
-CFLAGS_HWCAPS_x86_64_v3=("${CFLAGS_COMMON_ARCH_BASE[@]}" "-march=x86-64-v3" "-mtune=haswell" "-msse2" "-msse3" "-mssse3" "-msse4.2" "-mavx" "-mavx2")
-# TBD: Which -mtune to be chosen for x86_64 v4?
+CFLAGS_HWCAPS_x86_64_v2=("${CFLAGS_COMMON_ARCH_BASE[@]}" "-march=x86-64-v2" "-mtune=generic" "-msse2" "-msse3" "-mssse3" "-msse4.2")
+CFLAGS_HWCAPS_x86_64_v3=("${CFLAGS_COMMON_ARCH_BASE[@]}" "-march=x86-64-v3" "-mtune=generic" "-msse2" "-msse3" "-mssse3" "-msse4.2" "-mavx" "-mavx2")
 CFLAGS_HWCAPS_x86_64_v4=("${CFLAGS_COMMON_ARCH_BASE[@]}" "-march=x86-64-v4" "-mtune=generic" "-msse2" "-msse3" "-mssse3" "-msse4.2" "-mavx" "-mavx2" "-mavx512f" "-mavx512bw" "-mavx512cd" "-mavx512dq" "-mavx512vl")
 
-RUSTFLAGS_HWCAPS_x86_64_v2=("-Ctarget-cpu=x86-64-v2")
-RUSTFLAGS_HWCAPS_x86_64_v3=("-Ctarget-cpu=x86-64-v3")
-RUSTFLAGS_HWCAPS_x86_64_v4=("-Ctarget-cpu=x86-64-v4")
+RUSTFLAGS_HWCAPS_x86_64_v2=("-Ctarget-cpu=x86-64-v2" "-Ctarget-feature=+sse2,+sse3,+ssse3,+sse4.2")
+RUSTFLAGS_HWCAPS_x86_64_v3=("-Ctarget-cpu=x86-64-v3" "-Ctarget-feature=+sse2,+sse3,+ssse3,+sse4.2,+avx,+avx2")
+RUSTFLAGS_HWCAPS_x86_64_v4=("-Ctarget-cpu=x86-64-v4" "-Ctarget-feature=+sse2,+sse3,+ssse3,+sse4.2,+avx,+avx2,+avx512f,+avx512bw,+avx512cd,+avx512dq,+avx512vl")
 
 # CPPFLAGS must be set for function selection in preprocessing to work.
 CPPFLAGS_HWCAPS_x86_64_v2=("-march=x86-64-v2" "-msse2" "-msse3" "-mssse3" "-msse4.2")
-CPPFLAGS_HWCAPS_x86_64_v3=("-march=x86-64-v3" "-msse2" "-msse3" "-mssse3" "-msse4.2" "-mavx2")
-CPPFLAGS_HWCAPS_x86_64_v4=("-march=x86-64-v4" "-msse2" "-msse3" "-mssse3" "-msse4.2" "-mavx2" "-mavx512f" "-mavx512bw" "-mavx512cd" "-mavx512dq" "-mavx512vl")
+CPPFLAGS_HWCAPS_x86_64_v3=("-march=x86-64-v3" "-msse2" "-msse3" "-mssse3" "-msse4.2" "-mavx" "-mavx2")
+CPPFLAGS_HWCAPS_x86_64_v4=("-march=x86-64-v4" "-msse2" "-msse3" "-mssse3" "-msse4.2" "-mavx" "-mavx2" "-mavx512f" "-mavx512bw" "-mavx512cd" "-mavx512dq" "-mavx512vl")

--- a/arch/ppc64el.sh
+++ b/arch/ppc64el.sh
@@ -1,13 +1,24 @@
 #!/bin/bash
 ##arch/ppc64el.sh: Build definitions for ppc64el.
 ##@copyright GPL-2.0+
-CFLAGS_COMMON_ARCH_BASE=('-msecure-plt' '-mvsx' '-mabi=ieeelongdouble')
-CFLAGS_COMMON_ARCH=('-mcpu=power8' '-mtune=power8')
+CFLAGS_COMMON_ARCH_BASE=('-msecure-plt' '-mabi=ieeelongdouble')
+CFLAGS_COMMON_ARCH=('-mcpu=power8' '-mtune=power8' '-mvsx')
 RUSTFLAGS_COMMON_ARCH=('-Ctarget-cpu=pwr8' '-Ctarget-feature=+vsx,+altivec,+secure-plt' '-Clink-arg=-mabi=ieeelongdouble')
 
 HAS_HWCAPS=1
-# ppc64el only supports power8 and power9. The default is power8.
-HWCAPS=('power9')
-CFLAGS_HWCAPS_power9=("${CFLAGS_COMMON_ARCH_BASE[@]}" '-mcpu=power9' '-mtune=power9')
-CPPFLAGS_HWCAPS_power9=("${CFLAGS_COMMON_ARCH_BASE[@]}" '-mcpu=power9' '-mtune=power9')
+
+# List of HWCAPS subtargets in ppc64el, excluding power8 itself:
+#
+# power9 - Based on PowerISA v3.0, with enhanced VSX instructions.
+# power10 - Based on PowerISA v3.1, with Matrix-Multiply Assist (MMA) engines.
+HWCAPS=('power9' 'power10')
+
+# Compiler flags for each subtarget.
+CFLAGS_HWCAPS_power9=("${CFLAGS_COMMON_ARCH_BASE[@]}" '-mcpu=power9' '-mtune=power9' '-mvsx')
+CFLAGS_HWCAPS_power10=("${CFLAGS_COMMON_ARCH_BASE[@]}" '-mcpu=power10' '-mtune=power10' '-mvsx' '-mmma')
+
+CPPFLAGS_HWCAPS_power9=("${CFLAGS_COMMON_ARCH_BASE[@]}" '-mcpu=power9' '-mtune=power9' '-mvsx')
+CPPFLAGS_HWCAPS_power10=("${CFLAGS_COMMON_ARCH_BASE[@]}" '-mcpu=power10' '-mtune=power10' '-mvsx' '-mmma')
+
 RUSTFLAGS_HWCAPS_power9=('-Ctarget-cpu=pwr9' '-Ctarget-feature=+vsx,+altivec,+secure-plt' '-Clink-arg=-mabi=ieeelongdouble')
+RUSTFLAGS_HWCAPS_power10=('-Ctarget-cpu=pwr10' '-Ctarget-feature=+mma,+vsx,+altivec,+secure-plt' '-Clink-arg=-mabi=ieeelongdouble')

--- a/arch/ppc64el.sh
+++ b/arch/ppc64el.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 ##arch/ppc64el.sh: Build definitions for ppc64el.
 ##@copyright GPL-2.0+
-CFLAGS_COMMON_ARCH=('-mcpu=power8' '-mtune=power9' '-msecure-plt' '-mvsx' '-mabi=ieeelongdouble')
+CFLAGS_COMMON_ARCH_BASE=('-msecure-plt' '-mvsx' '-mabi=ieeelongdouble')
+CFLAGS_COMMON_ARCH=('-mcpu=power8' '-mtune=power8')
 RUSTFLAGS_COMMON_ARCH=('-Ctarget-cpu=pwr8' '-Ctarget-feature=+vsx,+altivec,+secure-plt' '-Clink-arg=-mabi=ieeelongdouble')
+
+HAS_HWCAPS=1
+# ppc64el only supports power8 and power9. The default is power8.
+HWCAPS=('power9')
+CFLAGS_HWCAPS_power9=("${CFLAGS_COMMON_ARCH_BASE[@]}" '-mcpu=power9' '-mtune=power9')
+CPPFLAGS_HWCAPS_power9=("${CFLAGS_COMMON_ARCH_BASE[@]}" '-mcpu=power9' '-mtune=power9')
+RUSTFLAGS_HWCAPS_power9=('-Ctarget-cpu=pwr9' '-Ctarget-feature=+vsx,+altivec,+secure-plt' '-Clink-arg=-mabi=ieeelongdouble')

--- a/arch/ppc64el.sh
+++ b/arch/ppc64el.sh
@@ -17,8 +17,13 @@ HWCAPS=('power9' 'power10')
 CFLAGS_HWCAPS_power9=("${CFLAGS_COMMON_ARCH_BASE[@]}" '-mcpu=power9' '-mtune=power9' '-mvsx')
 CFLAGS_HWCAPS_power10=("${CFLAGS_COMMON_ARCH_BASE[@]}" '-mcpu=power10' '-mtune=power10' '-mvsx' '-mmma')
 
-CPPFLAGS_HWCAPS_power9=("${CFLAGS_COMMON_ARCH_BASE[@]}" '-mcpu=power9' '-mtune=power9' '-mvsx')
-CPPFLAGS_HWCAPS_power10=("${CFLAGS_COMMON_ARCH_BASE[@]}" '-mcpu=power10' '-mtune=power10' '-mvsx' '-mmma')
+# ABI flags in CPPFLAGS confuses autoconf's compile test routines.
+# AC_LANG_PROGRAM calls $CC with the following arguments:
+#    $CC $CFLAGS $CPPFLAGS
+# When configure.ac tries to add someting to CFLAGS, the resulting
+# combination will still be overriden by CPPFLAGS.
+CPPFLAGS_HWCAPS_power9=('-mcpu=power9' '-mtune=power9' '-mvsx')
+CPPFLAGS_HWCAPS_power10=('-mcpu=power10' '-mtune=power10' '-mvsx' '-mmma')
 
 RUSTFLAGS_HWCAPS_power9=('-Ctarget-cpu=pwr9' '-Ctarget-feature=+vsx,+altivec,+secure-plt' '-Clink-arg=-mabi=ieeelongdouble')
 RUSTFLAGS_HWCAPS_power10=('-Ctarget-cpu=pwr10' '-Ctarget-feature=+mma,+vsx,+altivec,+secure-plt' '-Clink-arg=-mabi=ieeelongdouble')

--- a/lib/default-defines.sh
+++ b/lib/default-defines.sh
@@ -60,6 +60,9 @@ AB_SAN_LEK=0
 # Use BFD LD?
 AB_LD_BFD=1
 
+# Build for HWCAPS subtargets?
+AB_HWCAPS=0
+
 # Default testing flags
 ABTESTS=""
 ABTEST_AUTO_DETECT=yes

--- a/lib/default-defines.sh
+++ b/lib/default-defines.sh
@@ -66,6 +66,9 @@ AB_HWCAPS=0
 # Whether to trick autotools into thinking that we are *REALLY* cross compiling?
 # Set this to 1 in order to work around the issue that autotools trying to run
 # compile tests built for unsupported ISA levels without proper hardware.
+# This is rather a hack to prevent unsupported code from running, so keeping it
+# disabled. This is also not needed if configure does not run any compiled test
+# code.
 AB_HWCAPS_CROSS=0
 
 # Default testing flags

--- a/lib/default-defines.sh
+++ b/lib/default-defines.sh
@@ -63,6 +63,11 @@ AB_LD_BFD=1
 # Build for HWCAPS subtargets?
 AB_HWCAPS=0
 
+# Whether to trick autotools into thinking that we are *REALLY* cross compiling?
+# Set this to 1 in order to work around the issue that autotools trying to run
+# compile tests built for unsupported ISA levels without proper hardware.
+AB_HWCAPS_REALLY_CROSSING=0
+
 # Default testing flags
 ABTESTS=""
 ABTEST_AUTO_DETECT=yes

--- a/lib/default-defines.sh
+++ b/lib/default-defines.sh
@@ -66,7 +66,7 @@ AB_HWCAPS=0
 # Whether to trick autotools into thinking that we are *REALLY* cross compiling?
 # Set this to 1 in order to work around the issue that autotools trying to run
 # compile tests built for unsupported ISA levels without proper hardware.
-AB_HWCAPS_REALLY_CROSSING=0
+AB_HWCAPS_CROSS=0
 
 # Default testing flags
 ABTESTS=""

--- a/proc/12-arch-flags.sh
+++ b/proc/12-arch-flags.sh
@@ -5,14 +5,30 @@
 
 ab_arch_setflags() {
     local AB_FLAGS_FEATURES=(LTO PERMISSIVE)
-    local AB_FLAGS_TYPES=('' _OPTI _ARCH)
+    local AB_FLAGS_TYPES=('' _OPTI _ARCH_BASE _ARCH)
     local flagtypes=(LDFLAGS CFLAGS CPPFLAGS CXXFLAGS OBJCFLAGS OBJCXXFLAGS RUSTFLAGS)
     local features=('')
+    local hwcaps=()
     local _cc
+    local hwcaps_active=0
     _cc="$(basename "$CC")"
     _cc="${_cc%%-*}"
     _cc="${_cc^^}"
 
+    if bool "$HAS_HWCAPS" ; then
+        # Packager can enable it.
+        abdbg "This architecture has HWCAPS support."
+        if ! bool "$AB_HWCAPS" ; then
+            abdbg "HWCAPS is disabled for the current package."
+        else
+            hwcaps+=("${HWCAPS[@]}")
+            abdbg "HWCAPS subtargets: ${hwcaps[@]}"
+            if [ "${#hwcaps[@]}" -lt 1 ] ; then
+                abdie "HWCAPS support is enabled for $ARCH, but no subtargets specified. Please check ${AB}/arch/$ARCH.sh."
+            fi
+            hwcaps_active=1
+        fi
+    fi
     for feature in "${AB_FLAGS_FEATURES[@]}"; do
         if (("USE$feature")); then
             features+=("_$feature")
@@ -26,6 +42,12 @@ ab_arch_setflags() {
     for flagtype in "${flagtypes[@]}"; do
         declare "_${flagtype}"=""  # initialize the variable
         declare -a "_${flagtype}"  # convert to an array
+        if bool "$hwcaps_active" ; then
+            for cap in "${hwcaps[@]}" ; do
+                declare "_${flagtype}_HWCAPS_${cap//-/_}"=""
+                declare -a "_${flagtype}_HWCAPS_${cap//-/_}"
+            done
+        fi
         for suffix in "${AB_FLAGS_TYPES[@]}"; do
             for f in "${features[@]}"; do
                 for cc in "${_cc}" 'COMMON'; do
@@ -35,6 +57,22 @@ ab_arch_setflags() {
                     fi
                 done
             done
+            if [ "$suffix" = "_ARCH_BASE" ] && bool "$hwcaps_active"; then
+                # Inject HWCAPS flags arrays now.
+                # _COMMON_ARCH includes default arch.specific tunes.
+                for cap in "${HWCAPS[@]}" ; do
+                    if abisarray "_${flagtype}_HWCAPS_${cap//-/_}" ; then
+                        var="_${flagtype}[@]"
+                        arr=("${!var}")
+                        # Make a copy of _${flagtype}[@].
+                        ab_concatarray "_${flagtype}_HWCAPS_${cap//-/_}" "_${flagtype}"
+                        # If defined, concatenate the temporary array with the defined array.
+                        if abisarray "${flagtype}_HWCAPS_${cap//-/_}" ; then
+                            ab_concatarray "_${flagtype}_HWCAPS_${cap//-/_}" "${flagtype}_HWCAPS_${cap//-/_}"
+                        fi
+                    fi
+                done
+            fi
         done
         # merge flags if needed
         case "${flagtype}" in
@@ -49,7 +87,27 @@ ab_arch_setflags() {
         declare -n _tmp="_${flagtype}"
         export "${flagtype}"="${_tmp[*]}"
         abdbg "${flagtype}=${_tmp[*]}"
+
+    # Do the same thing if HWCAPS is enabled
+    if bool "$hwcaps_active" ; then
+        for cap in "${hwcaps[@]}" ; do
+        case "${flagtype}" in
+            CXXFLAGS|OBJCFLAGS)
+            ab_concatarray "_${flagtype}_HWCAPS_${cap//-/_}" "_CFLAGS_HWCAPS_${cap//-/_}"
+            ;;
+            OBJCXXFLAGS)
+            ab_concatarray "_${flagtype}_HWCAPS_${cap//-/_}" "_CXXFLAGS_HWCAPS_${cap//-/_}"
+            ;;
+        esac
+        declare -n _tmp="_${flagtype}_HWCAPS_${cap//-/_}"
+        unset "${flagtype}_HWCAPS_${cap//-/_}"
+        export "${flagtype}_HWCAPS_${cap//-/_}"="${_tmp[*]}"
+        abdbg "${flagtype}_HWCAPS_${cap//-/_}"="${_tmp[*]}"
+        done
+
+    fi
     done
+    export AB_HWCAPS_ACTIVE=$hwcaps_active
 }
 
 ab_arch_setflags

--- a/proc/50-build-exec.sh
+++ b/proc/50-build-exec.sh
@@ -42,9 +42,3 @@ if arch_findfile -2 beyond; then
 fi
 
 cd "$SRCDIR" || abdie "Unable to cd $SRCDIR: $?."
-
-unset -f BUILD_{START,READY,FINAL}
-unset __overrides
-for i in "${MIGRATE_REQUIRED[@]}"; do
-    abmm_array_mine_remove "$i"
-done

--- a/proc/51-build-hwcaps.sh
+++ b/proc/51-build-hwcaps.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+##proc/build_do: So we build it now
+##@copyright GPL-2.0+
+
+# See if HWCAPS is active.
+if ! bool "$AB_HWCAPS_ACTIVE" ; then
+	abinfo "HWCAPS is not active. Skipping builds for HWCAPS subtargtes."
+	unset -f BUILD_{START,READY,FINAL}
+	unset __overrides
+	for i in "${MIGRATE_REQUIRED[@]}"; do
+		abmm_array_mine_remove "$i"
+	done
+fi
+
+# We might need to do something specific to builds for HWCAPS subtargtes.
+# If none of these scripts exists, set up BLDDIR and PKGDIR, and invoke
+# the build templates.
+# If ABTYPE == self, and no HWCAPS build scripts exist, bail out.
+HWCAPS_PREPARE=
+HWCAPS_BUILD=
+HWCAPS_BEYOND=
+
+if [ -e "$SRCDIR"/autobuild/hwcaps/prepare ] ; then
+	abinfo "Using prepare script for HWCAPS subtargtes."
+	HWCAPS_PREPARE=hwcaps/prepare
+fi
+
+# Even if probed ABTYPE != self, use the build script unconditionally.
+if [ -e "$SRCDIR"/autobuild/hwcaps/build-"$ARCH" ] ; then
+	abinfo "Detected custom build script for HWCAPS subtargets of $ARCH."
+	HWCAPS_BUILD=hwcaps/build-"$ARCH"
+	export ABTYPE=self
+elif [ -e "$SRCDIR"/autobuild/hwcaps/build ] ; then
+	abinfo "Detected custom build script for HWCAPS subtargets."
+	HWCAPS_BUILD=hwcaps/build
+	export ABTYPE=self
+fi
+
+if [ "$ABTYPE" = "self" ] && [ -z "$HWCAPS_BUILD" ] ; then
+	abdie "HWCAPS build is enabled, and this project uses a custom build script. \
+		You need to supply a custom build script at autobuild/hwcaps/build-$ARCH."
+fi
+
+if [ -e "$SRCDIR"/autobuild/hwcaps/beyond ] ; then
+	abinfo "Using beyond script for HWCAPS subtargtes."
+	HWCAPS_BEYOND=hwcaps/beyond
+fi
+
+# Save BLDDIR and PKGDIR.
+export OLD_BLDDIR="$BLDDIR"
+export OLD_PKGDIR="$PKGDIR"
+
+# If an in-house build script is used, do not run it for every subtarget.
+if [ "$ABTYPE" != "self" ] ; then
+for cap in "${HWCAPS[@]}" ; do
+	# Set each build flags for the current subtarget
+	flags=(CFLAGS CXXFLAGS LDFLAGS OBJCFLAGS OBJCXXFLAGS RUSTFLAGS)
+	# Files to cleanup before each run. This has to be done if ABSHADOW=0.
+	files=(CMakeFiles CMakeCache.txt config.status)
+	for flag in "${flags[@]}" ; do
+		var="${flag}_HWCAPS_${cap//-/_}[*]"
+		export $flag="${!var}"
+	done
+
+	if ! bool "$ABSHADOW" ; then
+		abinfo "[$cap] Cleaning up ..."
+		for f in "${files[@]}" ; do
+			rm -rf $f &>/dev/null || true
+		done
+	else
+		# Set a dedicated BLDDIR for each subtarget.
+		export BLDDIR="$SRCDIR/abbuild-hwcaps-$cap"
+	fi
+	export PKGDIR="$SRCDIR/abdist-hwcaps-$cap"
+
+	abinfo "Building for HWCAPS subtarget $cap ..."
+	if arch_findfile hwcaps/prepare > /dev/null; then
+		abinfo 'Running pre-build (prepare) script ...'
+		arch_loadfile_strict hwcaps/prepare
+	fi
+
+	cd "$SRCDIR"
+	if ab_typecheck -f "build_${ABTYPE}_check"; then
+		abinfo "${ABTYPE} > Running check step ..."
+		"build_${ABTYPE}_check"
+	fi
+
+	if ab_typecheck -f "build_${ABTYPE}_audit"; then
+		abinfo "${ABTYPE} > Running audit step ..."
+		"build_${ABTYPE}_audit" || abdie "Audit failed: $?."
+	fi
+	# Trick autotools into thinking that we are performing a cross
+	# compilation. The resulting $cross_compile is `maybe', thus
+	# skipping a test run.
+	# This problem was observed on a non x86-64-v4 machine, while
+	# building gmp.
+	export AUTOTOOLS_TARGET=("--host=${ARCH_TARGET[$ARCH]}")
+
+	abinfo "[$cap] ${ABTYPE} > Running configure step ..."
+	"build_${ABTYPE}_configure" || abdie "Configure failed: $?."
+	abinfo "[$cap] ${ABTYPE} > Running build step ..."
+	"build_${ABTYPE}_build" || abdie "Build failed: $?."
+	abinfo "[$cap] ${ABTYPE} > Running install step ..."
+	"build_${ABTYPE}_install" || abdie "Install failed: $?."
+
+	cd "$SRCDIR" || abdie "Unable to cd $SRCDIR: $?."
+done # for cap in "${HWCAPS[@]}" ; do
+else # if [ "$ABTYPE" != "self" ] ; then
+	if [ -n "$HWCAPS_PREPARE" ] ; then
+		abinfo "[$cap] Running custom prepare script ..."
+		arch_loadfile_strict hwcaps/$(basename $HWCAPS_PREPARE) || abdie "Failed to run custom build script: $?."
+	fi
+	abinfo "[$cap] Running custom build script ..."
+	arch_loadfile_strict hwcaps/$(basename $HWCAPS_BUILD) || abdie "Failed to run custom build script: $?."
+fi # if [ "$ABTYPE" != "self" ] ; then
+
+[ -d "$PKGDIR" ] || abdie "51-build-hwcaps: Suspecting build failure due to missing PKGDIR."
+
+if arch_findfile hwcaps/beyond; then
+	abinfo 'Running after-build (beyond) script ...'
+	arch_loadfile_strict hwcaps/beyond
+fi
+
+cd "$SRCDIR" || abdie "Unable to cd $SRCDIR: $?."
+
+# TODO harvest artifacts.
+abdie "Enough for this time."
+unset -f BUILD_{START,READY,FINAL}
+unset __overrides
+for i in "${MIGRATE_REQUIRED[@]}"; do
+	abmm_array_mine_remove "$i"
+done

--- a/proc/51-build-hwcaps.sh
+++ b/proc/51-build-hwcaps.sh
@@ -91,11 +91,19 @@ for cap in "${HWCAPS[@]}" ; do
 		"build_${ABTYPE}_audit" || abdie "Audit failed: $?."
 	fi
 	# Trick autotools into thinking that we are performing a cross
-	# compilation. The resulting $cross_compile is `maybe', thus
+	# compilation. The resulting $cross_compiling is `maybe', thus
 	# skipping a test run.
 	# This problem was observed on a non x86-64-v4 machine, while
 	# building gmp.
-	export AUTOTOOLS_TARGET=("--host=${ARCH_TARGET[$ARCH]}")
+	# mpfr requires $cross_compiling = yes. So we have to do the real
+	# trick by using the generic target for --build.
+	if ! bool "$AB_HWCAPS_REALLY_CROSSING" ; then
+		export AUTOTOOLS_TARGET=("--host=${ARCH_TARGET[$ARCH]}")
+	else
+		generic_triple="${ARCH_TARGET[$ARCH]}"
+		generic_triple="${generic_triple/aosc/unknown}"
+		export AUTOTOOLS_TARGET=("--host=${ARCH_TARGET[$ARCH]}" "--build=${generic_triple}")
+	fi
 
 	abinfo "[$cap] ${ABTYPE} > Running configure step ..."
 	"build_${ABTYPE}_configure" || abdie "Configure failed: $?."

--- a/proc/51-build-hwcaps.sh
+++ b/proc/51-build-hwcaps.sh
@@ -121,7 +121,10 @@ for cap in "${HWCAPS[@]}" ; do
 		arch_loadfile_strict hwcaps/beyond
 	fi
 	[ -d "$PKGDIR" ] || abdie "51-build-hwcaps: Suspecting build failure due to missing PKGDIR."
-	if arch_findfile hwcaps/install ; then
+	if arch_findfile hwcaps/install-"$ARCH" ; then
+		abinfo "[$cap] Running custom installation script ..."
+		arch_loadfile_strict hwcaps/install-"$ARCH"
+	elif arch_findfile hwcaps/install ; then
 		abinfo "[$cap] Running custom installation script ..."
 		arch_loadfile_strict hwcaps/install
 	else
@@ -137,18 +140,21 @@ for cap in "${HWCAPS[@]}" ; do
 done # for cap in "${HWCAPS[@]}" ; do
 else # if [ "$ABTYPE" != "self" ] ; then
 	if arch_findfile hwcaps/prepare ; then
-		abinfo "[$cap] Running custom prepare script ..."
+		abinfo "[HWCAPS] Running custom prepare script ..."
 		arch_loadfile_strict hwcaps/prepare || abdie "Failed to run custom build script: $?."
 	fi
-	abinfo "[$cap] Running custom build script ..."
+	abinfo "[HWCAPS] Running custom build script ..."
 	arch_loadfile_strict hwcaps/$(basename $HWCAPS_BUILD) || abdie "Failed to run custom build script: $?."
 
 	if arch_findfile hwcaps/beyond; then
-		abinfo 'Running after-build (beyond) script ...'
+		abinfo "[HWCAPS] Running after-build (beyond) script ..."
 		arch_loadfile_strict hwcaps/beyond
 	fi
-	if arch_findfile hwcaps/install ; then
-		abinfo "[$cap] Running custom installation script ..."
+	if arch_findfile hwcaps/install-"$ARCH"	; then
+		abinfo "[HWCAPS] Running custom installation script for $ARCH ..."
+		arch_loadfile_strict hwcaps/install-$ARCH
+	elif arch_findfile hwcaps/install ; then
+		abinfo "[HWCAPS] Running custom installation script ..."
 		arch_loadfile_strict hwcaps/install
 	else
 		abwarn "It is advised to use hwcaps/install script to install libraries built for HWCAPS subtargets."

--- a/proc/51-build-hwcaps.sh
+++ b/proc/51-build-hwcaps.sh
@@ -99,7 +99,7 @@ for cap in "${HWCAPS[@]}" ; do
 	# building gmp.
 	# mpfr requires $cross_compiling = yes. So we have to do the real
 	# trick by using the generic target for --build.
-	if ! bool "$AB_HWCAPS_REALLY_CROSSING" ; then
+	if ! bool "$AB_HWCAPS_CROSS" ; then
 		export AUTOTOOLS_TARGET=("--host=${ARCH_TARGET[$ARCH]}")
 	else
 		generic_triple="${ARCH_TARGET[$ARCH]}"

--- a/proc/51-build-hwcaps.sh
+++ b/proc/51-build-hwcaps.sh
@@ -21,6 +21,11 @@ HWCAPS_PREPARE=
 HWCAPS_BUILD=
 HWCAPS_BEYOND=
 
+# Saved BLDDIR and PKGDIR.
+export PKG_BLDDIR=$BLDDIR
+export PKG_PKGDIR=$PKGDIR
+export HWCAPSDIR=$PKGDIR/$LIBDIR/glibc-hwcaps
+
 if [ -e "$SRCDIR"/autobuild/hwcaps/prepare ] ; then
 	abinfo "Using prepare script for HWCAPS subtargtes."
 	HWCAPS_PREPARE=hwcaps/prepare
@@ -47,13 +52,10 @@ if [ -e "$SRCDIR"/autobuild/hwcaps/beyond ] ; then
 	HWCAPS_BEYOND=hwcaps/beyond
 fi
 
-# Save BLDDIR and PKGDIR.
-export OLD_BLDDIR="$BLDDIR"
-export OLD_PKGDIR="$PKGDIR"
-
 # If an in-house build script is used, do not run it for every subtarget.
 if [ "$ABTYPE" != "self" ] ; then
 for cap in "${HWCAPS[@]}" ; do
+	export CUR_SUBTGT=$cap
 	# Set each build flags for the current subtarget
 	flags=(CPPFLAGS CFLAGS CXXFLAGS LDFLAGS OBJCFLAGS OBJCXXFLAGS RUSTFLAGS)
 	# Files to cleanup before each run. This has to be done if ABSHADOW=0.
@@ -125,7 +127,7 @@ for cap in "${HWCAPS[@]}" ; do
 		abdie "$cap: This build did not produce any libraries. How strange is that!"
 	fi
 	for f in "${files[@]}" ; do
-		install -Dvm755 -t "$OLD_PKGDIR"/usr/lib/glibc-hwcaps/"$cap"/ "$f"
+		install -Dvm755 -t "$PKG_PKGDIR"/usr/lib/glibc-hwcaps/"$cap"/ "$f"
 	done
 done # for cap in "${HWCAPS[@]}" ; do
 else # if [ "$ABTYPE" != "self" ] ; then
@@ -149,7 +151,7 @@ fi # if [ "$ABTYPE" != "self" ] ; then
 cd "$SRCDIR" || abdie "Unable to cd $SRCDIR: $?."
 
 # Set PKGDIR back to its original value.
-export PKGDIR="$OLD_PKGDIR"
+export PKGDIR="$PKG_PKGDIR"
 
 unset -f BUILD_{START,READY,FINAL}
 unset __overrides

--- a/qa/post/hwcaps.sh
+++ b/qa/post/hwcaps.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# qa/post/hwcaps.sh: QA checks for HWCAPS builds
+if ! bool "$AB_HWCAPS_ACTIVE" ; then
+	# Can't run this QA if HWCAPS is not active.
+	return
+fi
+
+# Check if $PKGDIR/$LIBDIR exists
+if [ ! -d "$PKGDIR"/"$LIBDIR"/glibc-hwcaps ] ; then
+	aberr "QA (E331): \`glibc-hwcaps' directory not found in PKGDIR/$LIBDIR!" | \
+		tee -a "$SRCDIR"/abqaerr.log
+	return
+fi
+
+# Check if any HWCAPS subdirectory exists
+hwcaps_subdirs=()
+for tgt in "${HWCAPS[@]}" ; do
+	dir="$PKGDIR"/"$LIBDIR"/glibc-hwcaps/"$tgt"
+	if [ -d "$dir" ] ; then
+		hwcaps_subdirs+=("$dir")
+	fi
+done
+if [ "${#hwcaps_subdirs[@]}" -lt 1 ] ; then
+	aberr "QA (E332): None of the HWCAPS subtargets have the corresponding subdirectory installed." | \
+		tee -a "$SRCDIR"/abqaerr.log
+	return
+fi
+
+# Check if any files present in $PKGDIR/$LIBDIR/glibc-hwcaps.
+FILES=($(find "$PKGDIR"/"$LIBDIR"/glibc-hwcaps -maxdepth 1 -type f,l))
+if [ "${#FILES[@]}" -ge 1 ] ; then
+	IFS=$'\n'
+	aberr "QA (E333): Stray file(s) found in the glibc-hwcaps directory:\n\n${FILES[*]}\n" | \
+		tee -a "$SRCDIR"/abqaerr.log
+	unset IFS
+fi
+
+# Check if all installed libraries have correct permissions
+badfiles=()
+for tgt in "${hwcaps_subdirs[@]}" ; do
+	FILES=($(find $tgt -type f,l -name '*.so.*' -not -perm /111))
+	# Non executable .so files found
+	for f in "${FILES[@]}" ; do
+		# Check if it is an ELF file by checking its magic
+		read -N4 content < $f
+		if [ "$content" == $'\x7fELF' ] ; then
+			badfiles+=("$f")
+		fi
+	done
+done
+if [ "${#badfiles[@]}" -ge 1 ] ; then
+	IFS=$'\n'
+	aberr "QA (E333): Non-executable shared object(s) found in glibc-hwcaps subdirectories:\n\n${badfiles[*]}\n" | \
+		tee -a "$SRCDIR"/abqaerr.log
+	unset IFS
+fi

--- a/templates/10-autotools.sh
+++ b/templates/10-autotools.sh
@@ -60,7 +60,12 @@ build_autotools_configure() {
 			|| abdie "Failed to enter shadow build directory: $?."
 	fi
 
-	if [[ "$ABHOST" = optenv* ]]
+	if [[ "x${AUTOTOOLS_TARGET[@]}" != "x" ]]
+	then
+		# $AUTOTOOLS_TARGET may be set internally by HWCAPS script.
+		# do nothing.
+		true
+	elif [[ "$ABHOST" = optenv* ]]
 	then
 		AUTOTOOLS_TARGET=("--host=${ARCH_TARGET[$ABHOST]}" "--target=${ARCH_TARGET[$ABHOST]}" "--build=${ARCH_TARGET[$ABHOST]}"
 				  "CC=$CC" "CXX=$CXX" "OBJC=$OBJC" "OBJCXX=$OBJCXX" LD="$LD")


### PR DESCRIPTION
This PR adds an implementation of packaging helpers to build HWCAPS for subtargets.

The documentation can be read here: https://hackmd.io/@Cyanoxygen/BysSMH-RR