### PR TITLE
Allow packages to skip maintscripts generation

### DIFF
--- a/lib/default-defines.sh
+++ b/lib/default-defines.sh
@@ -19,6 +19,11 @@ ABBUILDDEPONLY=no		# Avoid installing runtime dependencies when building?
 ABPATCHLAX=no			# Disallow fuzzy patching
 ABSPIRAL=yes			# Enable spiral provides generation
 
+AB_SKIP_MAINTSCRIPTS=()		# Names of the scriptlets to skip generating or installing
+				# Each element is one of prerm, postrm, preinst, postinst
+				# The corresponding script will not installed to DEBIAN/ of the final package
+AB_SKIP_ALLMAINTSCRIPTS=no	# Set to yes to skip all four maintscripts
+
 # Strict Autotools option checking?
 AUTOTOOLS_STRICT=yes
 

--- a/proc/01-core-defines.sh
+++ b/proc/01-core-defines.sh
@@ -41,6 +41,18 @@ if abisdefined FAIL_ARCH && abisdefined ALLOW_ARCH; then
 	abdie "Can not define FAIL_ARCH and ALLOW_ARCH at the same time."
 fi
 
+if bool "$AB_SKIP_ALLMAINTSCRIPTS" ; then
+	abinfo "Will not install maintscripts in this build."
+	AB_SKIP_MAINTSCRIPTS=('prerm' 'postrm' 'preinst' 'postinst')
+fi
+
+# Avoid using for loops to test if a string is in an array.
+# Convert the (indexed) array to an (assodiative) array.
+declare -A _AB_SKIP_MAINTSCRIPTS_
+for ele in "${AB_SKIP_MAINTSCRIPTS[@]}" ; do
+	_AB_SKIP_MAINTSCRIPTS_["$ele"]="$ele"
+done
+
 # shellcheck disable=SC2053
 if [ -n "$ALLOW_ARCH" ] && [ "${ABBUILD%%\/*}" != $ALLOW_ARCH ]; then
 	abdie "This package can only be built on $ALLOW_ARCH, not including $ABHOST."

--- a/proc/70-scriptlets.sh
+++ b/proc/70-scriptlets.sh
@@ -4,6 +4,15 @@
 mkdir -p abscripts
 
 for i in postinst prerm postrm preinst; do
+	# liushuyu: using an associative array can avoid using for loops to
+	# test if a string exists in an array.
+	if [ "x${_AB_SKIP_MAINTSCRIPTS_[$i]}" != "x" ] ; then
+		if [ -f "autobuild/$i" ] ; then
+			abdie "Conflict detected: $i should be skipped but autobuild/$i exists. Please remove $i from skip list or remove the file."
+		fi
+		abinfo "Skipping generating maintscript $i."
+		continue
+	fi
 	echo "#!/bin/bash" > abscripts/$i
 	cat autobuild/$i >> abscripts/$i 2>/dev/null || abinfo "Creating empty $i."
 	chmod 755 abscripts/$i


### PR DESCRIPTION
dpkg allows maintscripts to be absent. In this case it won't try to run non-existant maintscripts. Add an array and a switch to allow skipping generation some or all of maintscripts.