### PR TITLE
arch/loongarch64: comply with la-softdev-convention v0.2

### DIFF
--- a/arch/loongarch64.sh
+++ b/arch/loongarch64.sh
@@ -2,8 +2,26 @@
 ##arch/loongarch64.sh: Build definitions for LoongArch targets.
 ##@copyright GPL-2.0+
 
+# Per "Software Development and Build Convention for LoongArch
+# Architectures v0.2":
+#
+#   Desktop and server operating operating systems both need to support
+#   CPU platforms with at least 128-bit vector units.
+#
+#   To support 128-bit vector instructions, the compilation toolchain
+#   should use the -march=la64v1.0 compilation option when compiling
+#   desktop and server operating systems.
+#
+#   ...
+#
+#   The desktop and server operating system compilation toolchain should
+#   enable -mno-strict-align compilation option.
+#
+# Our default flags comply with the Convention.
+#
+# Ref: https://github.com/loongson/la-softdev-convention/blob/v0.2/la-softdev-convention.adoc
+CFLAGS_COMMON_ARCH=('-mabi=lp64d' '-march=la64v1.0' '-mno-strict-align')
 # la664 is only available on GCC >= 14 and Clang >= 19.
-CFLAGS_COMMON_ARCH=('-mabi=lp64d' '-march=loongarch64' '-mlsx')
 if ! bool "$USECLANG" && [ "$(echo __GNUC__ | $CC -E -xc - | tail -n 1)" -ge 14 ]; then
 	# Use `-mtune=la664' if we are on GCC >= 14.
 	CFLAGS_COMMON_ARCH+=('-mtune=la664')


### PR DESCRIPTION
Per "Software Development and Build Convention for LoongArch Architectures v0.2":

> Desktop and server operating operating systems both need to support CPU platforms with at least 128-bit vector units.
>
> To support 128-bit vector instructions, the compilation toolchain should use the -march=la64v1.0 compilation option when compiling desktop and server operating systems.
>
> ...
>
> The desktop and server operating system compilation toolchain should enable -mno-strict-align compilation option.

Update default arch/loongarch64 flags to comply with Convention v0.2.

Ref: https://github.com/loongson/la-softdev-convention/blob/v0.2/la-softdev-convention.adoc