### PR TITLE
arch/_common_switches: bump FORTIFY_SOURCE to 3

### DIFF
--- a/arch/_common_switches.sh
+++ b/arch/_common_switches.sh
@@ -5,7 +5,7 @@ if ((AB_FLAGS_SSP)); then CFLAGS_COMMON+=('-fstack-protector-strong' '--param=ss
 if ((AB_FLAGS_SCP)); then CFLAGS_GCC_COMMON+=('-fstack-clash-protection'); fi
 if ((AB_FLAGS_RRO)); then LDFLAGS_COMMON+=('-Wl,-z,relro'); fi
 if ((AB_FLAGS_NOW)); then LDFLAGS_COMMON+=('-Wl,-z,now'); fi
-if ((AB_FLAGS_FTF)); then CPPFLAGS_COMMON+=('-D_FORTIFY_SOURCE=2'); fi
+if ((AB_FLAGS_FTF)); then CPPFLAGS_COMMON+=('-D_FORTIFY_SOURCE=3'); fi
 if ((AB_FLAGS_SPECS)); then CFLAGS_GCC_OPTI+=('-specs=/usr/lib/gcc/specs/hardened-cc1'); fi
 if ((AB_FLAGS_O3)); then CFLAGS_COMMON_OPTI="${CFLAGS_COMMON_OPTI/O2/O3}"; fi
 if ((AB_FLAGS_OS)); then CFLAGS_COMMON_OPTI="${CFLAGS_COMMON_OPTI/O2/Os}"; fi


### PR DESCRIPTION
Fortification level 3 is supported sinced glibc 2.34 and GCC 12.

Enable it for better hardening performance.