### PR TITLE
arch: implement control-flow protection via AB_FLAGS_CFP

### DIFF
--- a/arch/_common_switches.sh
+++ b/arch/_common_switches.sh
@@ -10,6 +10,19 @@ if ((AB_FLAGS_SPECS)); then CFLAGS_GCC_OPTI+=('-specs=/usr/lib/gcc/specs/hardene
 if ((AB_FLAGS_O3)); then CFLAGS_COMMON_OPTI="${CFLAGS_COMMON_OPTI/O2/O3}"; fi
 if ((AB_FLAGS_OS)); then CFLAGS_COMMON_OPTI="${CFLAGS_COMMON_OPTI/O2/Os}"; fi
 if ((AB_FLAGS_EXC)); then CFLAGS_COMMON+=('-fexceptions'); fi
+# Only functions (via compiler and/or kernel, and hardware) on ...
+#
+#   - amd64 (x86-64): Intel CET (compiler: -fcf-protection=full,
+#     kernel: CONFIG_CET).
+#   - arm64 (AArch64): PAC + BTI (compiler: -mbranch-protection=standard,
+#     kernel: CONFIG_ARM64_BTI + ARM64_PTR_AUTH).
+if ((AB_FLAGS_CFP)); then
+	if ab_match_arch amd64; then
+		CFLAGS_COMMON+=('-fcf-protection=full')
+	elif ab_match_arch arm64; then
+		CFLAGS_COMMON+=('-mbranch-protection=standard')
+	fi
+fi
 
 # Clang can handle PIE and PIC properly, let it do the old job.
 if bool "$USECLANG"; then

--- a/lib/default-defines.sh
+++ b/lib/default-defines.sh
@@ -58,6 +58,9 @@ AB_FLAGS_SPECS=1
 # Enable table-based thread cancellation.
 AB_FLAGS_EXC=1
 
+# Enable control flow integrity protection.
+AB_FLAGS_CFP=1
+
 AB_SAN_ADD=0
 AB_SAN_THR=0
 AB_SAN_LEK=0

--- a/sets/exports.json
+++ b/sets/exports.json
@@ -37,6 +37,7 @@
     "AB_FLAGS_O3",
     "AB_FLAGS_OS",
     "AB_FLAGS_EXC",
+    "AB_FLAGS_CFP",
     "AB_FLAGS_PIC",
     "AB_FLAGS_PIE",
     "AB_SAN_ADD",


### PR DESCRIPTION
Control-flow proection only functions (via compiler and/or kernel, and hardware) on ...

- amd64 (x86-64): Intel CET (compiler: `-fcf-protection=full`, kernel: `CONFIG_CET`).
- arm64 (AArch64): PAC + BTI (compiler: `-mbranch-protection=standard`, kernel: `CONFIG_ARM64_BTI` + `ARM64_PTR_AUTH`).