### PR TITLE
templates/autotools: fix Non-standard configure script recognition

### DIFF
--- a/templates/10-autotools.sh
+++ b/templates/10-autotools.sh
@@ -3,8 +3,7 @@
 ##@copyright GPL-2.0+
 
 build_autotools_probe() {
-	[ -x "${configure=$SRCDIR/configure}" ] || \
-		[ -x "$SRCDIR"/autogen.sh ] || \
+	[ -x "$SRCDIR"/autogen.sh ] || \
 		[ -x "$SRCDIR"/bootstrap ] || \
 		[ -f "$SRCDIR"/configure.ac ]
 }


### PR DESCRIPTION
For Non-standard configure scripts
before:
```bash
[INFO]: Re-generating Autotools scripts ...
In file included from /usr/bin/autobuild:13
from /usr/lib/autobuild4/proc/50-build-exec.sh:29
from /usr/lib/autobuild4/templates/10-autotools.sh:51 /usr/lib/autobuild4/templates/10-autotools.sh:36: In function `build_autotools_regenerate': /usr/lib/autobuild4/templates/10-autotools.sh:36: error: command exited with 1 35 | else
> 36 | abdie 'Necessary files not found for script regeneration - non-standard Autotools source?'
37 | fi

autobuild encountered an error and couldn't continue. Necessary files not found for script regeneration - non-standard Autotools source?
```
after:
```bash
2: [DEBUG]: Registered filter: retro_drop_docs
2: In file included from /home/runner/work/autobuild4/autobuild4/build/tests/ab4.sh:1 2: /home/runner/work/autobuild4/autobuild4/proc/30-build-probe.sh:15: In function `source': 2: /home/runner/work/autobuild4/autobuild4/proc/30-build-probe.sh:15: error: command raised an error here
2:    14 | if [ -z "$ABTYPE" ]; then
2: >  15 | 	abdie "Cannot determine build type."
2:    16 | fi
2: 
2: autobuild encountered an error and couldn't continue.
2: Cannot determine build type.
```