### PR TITLE
qa: add QA error 'build' file exist when ABTYPE is set to non 'self' value

### DIFF
--- a/qa/pre/variables.sh
+++ b/qa/pre/variables.sh
@@ -11,3 +11,7 @@ done
 if ! grep -qF "$PKGSEC" "$AB/sets/section"; then
   aberr "QA (E104): $PKGSEC not in sets/section." | tee -a "$SRCDIR"/abqaerr.log
 fi
+
+if arch_findfile -2 build && abisdefined ABTYPE && [[ "$ABTYPE" != "self" ]]; then
+  aberr "QA (E105): free-formed build script exist while using a template." | tee -a "$SRCDIR"/abqaerr.log
+fi


### PR DESCRIPTION
this reduce chance of confusion when switch package between templates and build file