### PR TITLE
loongson3: Drop -mfix-loongson3-llsc

### DIFF
--- a/arch/loongson3.sh
+++ b/arch/loongson3.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ##arch/loongson3.sh: Build definitions for Loongson 3A/B 1000-4000+.
 ##@copyright GPL-2.0+
-CFLAGS_GCC_ARCH=('-mabi=64' '-march=gs464' '-mtune=gs464e' '-mfix-loongson3-llsc' '-mxgot')
+CFLAGS_GCC_ARCH=('-mabi=64' '-march=gs464' '-mtune=gs464e' '-mxgot')
 CFLAGS_CLANG_ARCH=('-mabi=64' '-march=mips64r2')
 RUSTFLAGS_COMMON_ARCH=('-Clink-arg=-Wl,-build-id=sha1')
 


### PR DESCRIPTION
For Loongson 3 two workarounds for LL/SC may be needed:

    1:
    sync               # "LLSYNC"
    ll	$7,0($4)
    bne	$7,$3,2f
    li	$2,0
    move	$1,$6
    sc	$1,0($4)
    beq	$1,$0,1b
    li	$2,1
    2:
    sync               # "TGTSYNC"

The message of the AOSC patch adding -mfix-loongson3-llsc to GCC claims "Binutils only handles LLSYNC, not TGTSYNC."  It's no longer correct: the patch was written in 2018, but when the Binutils LL/SC errata workaround was upstreamed in 2019 it actually handles both LLSYNC and TGTSYNC.

As in abbs we already configure Binutils to enable the workaround by default for loongson3, we don't need the GCC workaround anymore.  Drop it here now, and it'll be dropped from our GCC patchset too.

Link: https://github.com/AOSC-Dev/aosc-os-abbs/blob/6e87aebe7f8d/app-devel/binutils/01-main/defines#L35
Link: https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=6f2117ba3892