### PR TITLE
filters/optenv32_drop_shared_files.sh: adjust for aosc-aaa+32

### DIFF
--- a/arch/optenv32.sh
+++ b/arch/optenv32.sh
@@ -3,22 +3,55 @@
 ##@copyright GPL-2.0+
 # OS Tree definitions
 PREFIX="/opt/32"
-BINDIR="/opt/32/bin"
-LIBDIR="/opt/32/lib"
-# PREFIX/etc and PREFIX/share will be replaced by symlinks to /etc and
-# /usr/share.
-BINFMTD="/usr/lib/binfmt.d"
-INCLUDE="/opt/32/include"
-LIBEXEC="/opt/32/libexec"
-USRSRC="/opt/32/src"
-SYDDIR="/opt/32/lib/systemd/system"
-SYDSCR="/opt/32/lib/systemd/scripts"
-TMPFILE="/usr/lib/tmpfiles.d"
-JAVAHOME="/opt/32/lib/java"
-QT4DIR="/opt/32/lib/qt4"
-QT5DIR="/opt/32/lib/qt5"
-QT4BIN="/opt/32/lib/qt4/bin"
-QT5BIN="/opt/32/lib/qt5/bin"
+BINDIR="$PREFIX/bin"
+LIBDIR="$PREFIX/lib"
+
+# PREFIX/etc and PREFIX/share will be replaced by symlinks to /etc, /usr/share,
+# and /var, respectively.
+PREFIX="$PREFIX"
+BINDIR="$PREFIX/bin"
+LIBDIR="$PREFIX/lib"
+SYSCONF="$PREFIX/etc"
+CONFD="$PREFIX/etc/conf.d"
+ETCDEF="$PREFIX/etc/default"
+LDSOCONF="$PREFIX/etc/ld.so.conf.d"
+FCCONF="$PREFIX/etc/fonts"
+LOGROT="$PREFIX/etc/logrotate.d"
+CROND="$PREFIX/etc/cron.d"
+SKELDIR="$PREFIX/etc/skel"
+BINFMTD="$PREFIX/lib/binfmt.d"
+X11CONF="$PREFIX/etc/X11/xorg.conf.d"
+STATDIR="$PREFIX/var"
+INCLUDE="$PREFIX/include"
+BOOTDIR="$PREFIX/boot"
+LIBEXEC="$PREFIX/libexec"
+MANDIR="$PREFIX/share/man"
+FDOAPP="$PREFIX/share/applications"
+FDOICO="$PREFIX/share/icons"
+FONTDIR="$PREFIX/share/fonts"
+USRSRC="$PREFIX/src"
+VARLIB="$PREFIX/var/lib"
+RUNDIR="$PREFIX/run"
+DOCDIR="$PREFIX/share/doc"
+LICDIR="$PREFIX/share/doc/licenses"
+SYDDIR="$PREFIX/lib/systemd/system"
+SYDSCR="$PREFIX/lib/systemd/scripts"
+TMPFILE="$PREFIX/lib/tmpfiles.d"
+PAMDIR="$PREFIX/etc/pam.d"
+JAVAMOD="$PREFIX/share/java"
+JAVAHOME="$PREFIX/lib/java"
+GTKDOC="$PREFIX/share/gtk-doc"
+GSCHEMAS="$PREFIX/share/glib-2.0/schemas"
+THEMES="$PREFIX/share/themes"
+BASHCOMP="$PREFIX/share/bash-completion"
+ZSHCOMP="$PREFIX/share/zsh-completion"
+PROFILED="$PREFIX/etc/profile.d"
+LOCALES="$PREFIX/share/locales"
+VIMDIR="$PREFIX/share/vim"
+QT4DIR="$PREFIX/lib/qt4"
+QT5DIR="$PREFIX/lib/qt5"
+QT4BIN="$PREFIX/lib/qt4/bin"
+QT5BIN="$PREFIX/lib/qt5/bin"
 
 # optenv32 packages should be packaged as amd64.
 export DPKG_ARCH="amd64"
@@ -34,5 +67,5 @@ CFLAGS_COMMON_ARCH=('-fomit-frame-pointer' '-march=x86-64' '-mtune=znver4' '-mss
 RUSTFLAGS_COMMON_ARCH=('-Clinker=/opt/32/bin/clang' '-Ctarget-cpu=x86-64')
 ab_remove_args RUSTFLAGS_COMMON_OPTI_LTO '-Clinker=clang'
 
-export PKG_CONFIG_PATH="/opt/32/lib/pkgconfig:/usr/share/pkgconfig"
+export PKG_CONFIG_PATH="/opt/32/lib/pkgconfig:/opt/32/share/pkgconfig"
 unset LDFLAGS_COMMON_CROSS_BASE

--- a/filters/optenv32_drop_shared_files.sh
+++ b/filters/optenv32_drop_shared_files.sh
@@ -3,7 +3,7 @@
 ##@copyright GPL-2.0+
 
 # Paths to be removed from PKGDIR.
-OPTENV_SHARED_PATHS=("$PREFIX/etc" "$PREFIX/share" "$PREFIX/var" "/etc" "/share" "/var" "/usr/share")
+OPTENV_SHARED_PATHS=("$PREFIX/etc" "$PREFIX/share" "$PREFIX/var")
 filter_optenv_drop_shared_files() {
 	if [[ "$ABHOST" = optenv* ]] ; then
 		abinfo "optenv target detected, removing shared files from the package directory ..."
@@ -12,20 +12,6 @@ filter_optenv_drop_shared_files() {
 				abinfo "Removing $rmpath from the package directory ..."
 				# Probably way too verbose.
 				rm -r "$PKGDIR"/"$rmpath"
-				case "${rmpath/$PREFIX\//}" in
-					etc)
-						abinfo "Replacing $PREFIX/$rmpath with symlink to /etc ..."
-						ln -sv /etc "$PKGDIR/$PREFIX/etc"
-						;;
-					var)
-						abinfo "Replacing $PREFIX/$rmpath with symlink to /var ..."
-						ln -sv /var "$PKGDIR/$PREFIX/var"
-						;;
-					share)
-						abinfo "Replacing $PREFIX/$rmpath with symlink to /usr/share ..."
-						ln -sv /usr/share "$PKGDIR/$PREFIX/share"
-						;;
-				esac
 			fi
 		done
 	else


### PR DESCRIPTION
- Do not create replacement symlinks - handle this in aosc-aaa+32 as it creates directory structures for the base optenv32 environment.
- Do not remove non-prefixed data files as it will be part of the symlinked structure.