### PR TITLE
templates/15-gomod: make go get targets customizable too

### DIFF
--- a/templates/15-gomod.sh
+++ b/templates/15-gomod.sh
@@ -32,9 +32,11 @@ build_gomod_configure() {
 	cd "$BLDDIR" \
 		|| abdie "Failed to cd $SRCDIR/abbuild: $?."
 
-	abinfo "Fetching Go modules dependencies ..."
-	GOPATH="$SRCDIR/abgopath" go get .. \
-		|| abdie "Failed to fetch Go module dependencies: $?."
+	for package in "${GO_PACKAGES[@]}"; do
+		abinfo "Fetching Go modules ($package) dependencies ..."
+		GOPATH="$SRCDIR/abgopath" go get "$SRCDIR/$package" \
+			|| abdie "Failed to fetch Go module dependencies: $?."
+	done
 }
 
 build_gomod_build() {


### PR DESCRIPTION
Tested the following three packages:
- sing-box(no need to manually define GO_PACKAGES and can run `go get` in `$SRCDIR`) now can be built properly.
- [opentofu](https://github.com/AOSC-Dev/aosc-os-abbs/pull/10546)(need to manually define GO_PACKAGES and can run `go get` in `$SRCDIR`) now can be built properly.
- gdu(need to manually define GO_PACKAGES but can not run `go get` in `$SRCDIR`) now can be built properly.