### PR TITLE
templates/15-gomod.sh: fix mkdir errors

### DIFF
--- a/templates/15-gomod.sh
+++ b/templates/15-gomod.sh
@@ -27,7 +27,7 @@ build_gomod_configure() {
 		abdie "ABSHADOW must be set to true for this build type: $?."
 	fi
 
-	mkdir "$BLDDIR" \
+	mkdir -pv "$BLDDIR" \
 		|| abdie "Failed to create $SRCDIR/abbuild: $?."
 	cd "$BLDDIR" \
 		|| abdie "Failed to cd $SRCDIR/abbuild: $?."


### PR DESCRIPTION
Previously when a package uses gomod template multiple times, sub-packages built after the first one would fail because $SRCDIR/abbuild exists.

This patch fixes mkdir errors by adding -p option to mkdir, avoiding re-creation of subdirs and returning errors when $SRCDIR/abbuild has already been created by previous builds.

See [incus build error log](https://buildit.aosc.io/logs/92418-incus-6.14.0-amd64-Ricks-Ryzen-Box-2025-06-28-21:47:30.txt).