### PR TITLE
sets/section: new section `{contrib,nonfree}/metrics`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(autobuild VERSION 4.12.5 HOMEPAGE_URL "https://github.com/AOSC-Dev/autobuild4" LANGUAGES C CXX)
+project(autobuild VERSION 4.12.6 HOMEPAGE_URL "https://github.com/AOSC-Dev/autobuild4" LANGUAGES C CXX)
 
 include(GNUInstallDirs)
 include(CheckTypeSize)

--- a/sets/section
+++ b/sets/section
@@ -98,6 +98,7 @@ non-free/LxQt
 non-free/MATE
 non-free/mail
 non-free/math
+non-free/metrics
 non-free/misc
 non-free/net
 non-free/news
@@ -159,6 +160,7 @@ contrib/LxQt
 contrib/MATE
 contrib/mail
 contrib/math
+contrib/metrics
 contrib/misc
 contrib/net
 contrib/news


### PR DESCRIPTION
Fix #58 which did not add `{contrib,nonfree}/metrics`