### PR TITLE
feat: export CGO_{C,CPP,CXX,LD}FLAGS from un-prefixed counterparts

### DIFF
--- a/proc/12-arch-flags.sh
+++ b/proc/12-arch-flags.sh
@@ -88,6 +88,15 @@ ab_arch_setflags() {
         export "${flagtype}"="${_tmp[*]}"
         abdbg "${flagtype}=${_tmp[*]}"
 
+        # export CGO counterparts for CFLAGS, CPPFLAGS, CXXFLAGS, and LDFLAGS.
+        # see <https://go.dev/src/cmd/cgo/doc.go>.
+        case "${flagtype}" in
+            CFLAGS|CPPFLAGS|CXXFLAGS|LDFLAGS)
+            export "CGO_${flagtype}"="${_tmp[*]}"
+            abdbg "CGO_${flagtype}=${_tmp[*]}"
+            ;;
+        esac
+
     # Do the same thing if HWCAPS is enabled
     if bool "$hwcaps_active" ; then
         for cap in "${hwcaps[@]}" ; do


### PR DESCRIPTION
Export `CGO_{C,CXX,LD}FLAGS` from their un-prefixed counterparts. This way, we could eliminate duplicated per-package CGO export preambles like:

```sh
export CGO_CFLAGS="${CFLAGS}"
export CGO_CPPFLAGS="${CPPFLAGS}"
export CGO_CXXFLAGS="${CXXFLAGS}"
export CGO_LDFLAGS="${LDFLAGS}"
```

See also <https://go.dev/src/cmd/cgo/doc.go>.