### PR TITLE
32bit fixes 20260423

### DIFF
--- a/arch/_common_switches.sh
+++ b/arch/_common_switches.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 ##arch/_common_switches.sh: Switches sourced after defines.
 ##@copyright GPL-2.0+
+if ((AB_FLAGS_ATOMIC)); then CFLAGS_COMMON+=('-latomic'); LDFLAGS_COMMON+=('-latomic'); fi
 if ((AB_FLAGS_SSP)); then CFLAGS_COMMON+=('-fstack-protector-strong' '--param=ssp-buffer-size=4'); fi
 if ((AB_FLAGS_SCP)); then CFLAGS_GCC_COMMON+=('-fstack-clash-protection'); fi
 if ((AB_FLAGS_RRO)); then LDFLAGS_COMMON+=('-Wl,-z,relro'); fi

--- a/arch/_common_switches.sh
+++ b/arch/_common_switches.sh
@@ -10,6 +10,7 @@ if ((AB_FLAGS_FTF)); then CPPFLAGS_COMMON+=('-U_FORTIFY_SOURCE' '-D_FORTIFY_SOUR
 if ((AB_FLAGS_O3)); then CFLAGS_COMMON_OPTI="${CFLAGS_COMMON_OPTI/O2/O3}"; fi
 if ((AB_FLAGS_OS)); then CFLAGS_COMMON_OPTI="${CFLAGS_COMMON_OPTI/O2/Os}"; fi
 if ((AB_FLAGS_EXC)); then CFLAGS_COMMON+=('-fexceptions'); fi
+if ((AB_FLAGS_Y2038)); then CPPFLAGS_COMMON+=('-D_FILE_OFFSET_BITS=64' '-D_TIME_BITS=64'); fi
 # Only functions (via compiler and/or kernel, and hardware) on ...
 #
 #   - amd64 (x86-64): Intel CET (compiler: -fcf-protection=full,

--- a/arch/armv4.sh
+++ b/arch/armv4.sh
@@ -8,3 +8,6 @@ LDFLAGS_COMMON_ARCH=('-Wl,--gc-sections')
 
 CFLAGS_COMMON_ARCH+=('-march=armv4' '-mfloat-abi=soft')
 CFLAGS_GCC_ARCH=('-mtune=strongarm110')
+
+# Enable Y2038 (largefile + time64) mitigation.
+AB_FLAGS_Y2038=1

--- a/arch/armv6hf.sh
+++ b/arch/armv6hf.sh
@@ -8,3 +8,6 @@ LDFLAGS_COMMON_ARCH=('-Wl,--gc-sections')
 
 CFLAGS_COMMON_ARCH+=('-march=armv6' '-mfloat-abi=hard')
 CFLAGS_GCC_ARCH=('-mtune=arm1176jz-s')
+
+# Enable Y2038 (largefile + time64) mitigation.
+AB_FLAGS_Y2038=1

--- a/arch/armv7hf.sh
+++ b/arch/armv7hf.sh
@@ -8,3 +8,6 @@ LDFLAGS_COMMON_ARCH=('-Wl,--gc-sections')
 
 CFLAGS_COMMON_ARCH+=('-march=armv7-a' '-mfloat-abi=hard' '-mfpu=neon' '-mthumb')
 CFLAGS_GCC_ARCH=('-mtune=cortex-a7')
+
+# Enable Y2038 (largefile + time64) mitigation.
+AB_FLAGS_Y2038=1

--- a/arch/i486.sh
+++ b/arch/i486.sh
@@ -6,7 +6,9 @@
 CFLAGS_COMMON_ARCH=('-O2' '-fno-tree-ch' '-ffunction-sections' '-fdata-sections' '-mno-omit-leaf-frame-pointer')
 LDFLAGS_COMMON_ARCH=('-Wl,--gc-sections')
 
-CPPFLAGS_COMMON_ARCH=('-D_TIME_BITS=64' '-D_FILE_OFFSET_BITS=64')
 CFLAGS_COMMON_ARCH+=('-march=i486' '-mtune=generic')
 
 RUSTFLAGS_COMMON_ARCH=('-Ctarget-cpu=i486' '-Clink-args=-latomic')
+
+# Enable Y2038 (largefile + time64) mitigation.
+AB_FLAGS_Y2038=1

--- a/arch/powerpc.sh
+++ b/arch/powerpc.sh
@@ -13,3 +13,6 @@ CFLAGS_COMMON_ARCH+=('-m32' '-mcpu=603' '-mtune=G4' '-mno-altivec' '-msecure-plt
 GOFLAGS=${GOFLAGS/-buildmode=pie/}
 
 RUSTFLAGS_COMMON_ARCH=('-Ctarget-cpu=603' '-Ctarget-feature=+hard-float,+secure-plt,-altivec')
+
+# Enable Y2038 (largefile + time64) mitigation.
+AB_FLAGS_Y2038=1

--- a/lib/default-defines.sh
+++ b/lib/default-defines.sh
@@ -36,6 +36,11 @@ ABINFOCOMPRESS=1
 ABELFDEP=0	# Guess dependencies from ldd?
 ABSTRIP=1	# Should ELF be stripped off debug and unneeded symbols?
 
+# Add -latomic to compiler flags.
+# Useful when dealing with architectures lacking 64-bit and longer atomic
+# operations.
+AB_FLAGS_ATOMIC=0
+
 # Use -O3 instead?
 AB_FLAGS_O3=0
 

--- a/lib/default-defines.sh
+++ b/lib/default-defines.sh
@@ -64,6 +64,10 @@ AB_FLAGS_EXC=1
 # Enable control flow integrity protection.
 AB_FLAGS_CFP=1
 
+# Enable Y2038 mitigations:
+# -D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64
+AB_FLAGS_Y2038=0
+
 AB_SAN_ADD=0
 AB_SAN_THR=0
 AB_SAN_LEK=0

--- a/native/abnativefunctions.cpp
+++ b/native/abnativefunctions.cpp
@@ -368,7 +368,10 @@ static int abdie(WORD_LIST *list) {
   // cd "$SRCDIR"
   const auto *srcdir_v = find_variable("SRCDIR");
   if (srcdir_v && srcdir_v->value) {
-    chdir(srcdir_v->value);
+    if (chdir(srcdir_v->value) != 0) {
+      log->logException(fmt::format("Unable to chdir() to {0}: {1}",
+                                    srcdir_v->value, strerror(errno)));
+    }
   }
   log->logDiagnostic(diag);
   log->logException(message ? message : std::string());

--- a/proc/01-core-defines.sh
+++ b/proc/01-core-defines.sh
@@ -29,6 +29,8 @@ export AB ABBUILD ABHOST ABTARGET
 
 ab_parse_set_modifiers
 
+# Load defines for ABHOST.
+# NOTE: optenv32 is defined as an architecture.
 arch_loaddefines -2 defines || abdie "Failed to source defines file: $?."
 
 if [[ "$ABBUILD" == "$ABHOST" ]]; then
@@ -66,6 +68,12 @@ fi
 if abisdefined FAIL_ARCH && abisdefined ALLOW_ARCH; then
 	abdie "Can not define FAIL_ARCH and ALLOW_ARCH at the same time."
 fi
+
+# NOTE: Some defines may override AB_FLAGS_* defined in an arch-specific
+# manner.
+# Take AB_FLAGS_Y2038 for example, some packages may need to disable this
+# flag in order to build, such as v4l-utils.
+arch_loaddefines -2 defines || abdie "Failed to source defines file: $?."
 
 if bool "$AB_SKIP_ALLMAINTSCRIPTS" ; then
 	abinfo "Will not install maintscripts in this build."

--- a/sets/exports.json
+++ b/sets/exports.json
@@ -28,6 +28,7 @@
   ],
   "filter_elf": ["ABSTRIP", "ABSPLITDBG", "SYMTAB"],
   "flags": [
+    "AB_FLAGS_ATOMIC",
     "AB_FLAGS_SSP",
     "AB_FLAGS_SCP",
     "AB_FLAGS_RRO",

--- a/sets/exports.json
+++ b/sets/exports.json
@@ -40,6 +40,7 @@
     "AB_FLAGS_CFP",
     "AB_FLAGS_PIC",
     "AB_FLAGS_PIE",
+    "AB_FLAGS_Y2038",
     "AB_SAN_ADD",
     "AB_SAN_THR",
     "AB_SAN_LEK",

--- a/templates/11-cmakeninja.sh
+++ b/templates/11-cmakeninja.sh
@@ -18,8 +18,13 @@ build_cmakeninja_configure() {
 	fi
 	BUILD_START
 
+	# NOTE: CMake does not add ENV{CPPFLAGS} to
+	# CMAKE_${LANGUAGE}_FLAGS_INIT. We must either patch CMake or add
+	# CPPFLAGS to CFLAGS and CXXFLAGS manually.
+	export CFLAGS="$CPPFLAGS $CFLAGS"
+	export CXXFLAGS="$CPPFLAGS $CXXFLAGS"
 	abinfo "Running CMakeLists.txt to generate Ninja Configuration ..."
-    ab_tostringarray CMAKE_AFTER
+	ab_tostringarray CMAKE_AFTER
 	cmake "$SRCDIR" "${CMAKE_DEF[@]}" "${CMAKE_AFTER[@]}" -GNinja \
 			|| abdie "Failed to run CMakeLists.txt: $?."
 }

--- a/templates/12-cmake.sh
+++ b/templates/12-cmake.sh
@@ -16,10 +16,15 @@ build_cmake_configure() {
 			|| abdie "Failed to enter shadow build directory: $?."
 	fi
 
-    BUILD_START
+	BUILD_START
 
+	# NOTE: CMake does not add ENV{CPPFLAGS} to
+	# CMAKE_${LANGUAGE}_FLAGS_INIT. We must either patch CMake or add
+	# CPPFLAGS to CFLAGS and CXXFLAGS manually.
+	export CFLAGS="$CPPFLAGS $CFLAGS"
+	export CXXFLAGS="$CPPFLAGS $CXXFLAGS"
 	abinfo "Running CMakeLists.txt to generate Makefile ..."
-    ab_tostringarray CMAKE_AFTER
+	ab_tostringarray CMAKE_AFTER
 	cmake "$SRCDIR" "${CMAKE_DEF[@]}" "${CMAKE_AFTER[@]}" \
 			|| abdie "Failed to run CMakeLists.txt: $?."
 }


### PR DESCRIPTION
- Add `AB_FLAGS_ATOMIC` switch to add `-latomic` to CFLAGS, CXXFLAGS and LDFLAGS.
- Prepend CPPFLAGS to CFLAGS and CXXFLAGS for CMake as it does not process `ENV{CPPFLAGS}`.
- Add `AB_FLAGS_Y2038` switch to add `-D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64` to CPPFLAGS.