### PR TITLE
sets/exports: add ABTYPE to allow ABTYPE__ARCHGROUP

### DIFF
--- a/sets/exports.json
+++ b/sets/exports.json
@@ -24,7 +24,8 @@
     "ABAPMS",
     "BUILDDEP",
     "PKGPRDEP",
-    "PKGEPOCH_SPIRAL"
+    "PKGEPOCH_SPIRAL",
+    "ABTYPE"
   ],
   "filter_elf": ["ABSTRIP", "ABSPLITDBG", "SYMTAB"],
   "flags": [


### PR DESCRIPTION
One use case is librsvg, where it uses mainline releases for mainline architectures, and 2.40.z for Afterglow to keep it Rust-free, which uses Autotools.