### PR TITLE
Afterglow fixes 20260630

### DIFF
--- a/proc/01-core-defines.sh
+++ b/proc/01-core-defines.sh
@@ -92,8 +92,37 @@ if [ -n "$ALLOW_ARCH" ] && [ "${ABBUILD%%\/*}" != $ALLOW_ARCH ]; then
 	abdie "This package can only be built on $ALLOW_ARCH, not including $ABHOST."
 fi
 # shellcheck disable=SC2053
-[[ ${ABHOST} != $FAIL_ARCH ]] ||
+# Now, we need to match not only the ARCH itself, we also have to match every
+# ABHOST_GROUPs (e.g. retro, mainline, etc.).
+# Three types of expressions are handled:
+# - "!(a|b|c)", matching anything except a, b and c, so the build is only
+#   available to a, b and c.
+# - "@(a|b|c)", matching a, b and c, so the build is not available to a,
+#   b and c.
+# - "arch" or "group", disallowing build for one arch/group.
+# NOTE:
+# - Expressions such as "a|b|c" or "(a|b|c)" are invalid.
+last_status=0
+if [ "${FAIL_ARCH##\!}" != "$FAIL_ARCH" ] ; then
+	chk_op="!="
+else
+	chk_op="=="
+fi
+for match in "$ABHOST" "${ABHOST_GROUP[@]}" ; do
+	if eval "[[ \$match $chk_op \$FAIL_ARCH ]]" ; then
+		last_status=0
+		break
+	else
+		last_status=1
+	fi
+done
+if [ "$chk_op" = "==" ] ; then
+	last_status="$(( !last_status ))"
+fi
+if [ "$last_status" != "0" ] ; then
 	abdie "This package cannot be built for $FAIL_ARCH, e.g. $ABHOST."
+fi
+unset last_status chk_op
 
 if ! bool "$ABSTRIP" && bool "$ABSPLITDBG"; then
 	abwarn "QA: ELF stripping is turned OFF."

--- a/proc/01-core-defines.sh
+++ b/proc/01-core-defines.sh
@@ -65,8 +65,8 @@ load_strict "$AB"/lib/default-flags.sh
 if ! abisdefined DPKG_ARCH ; then
 	export DPKG_ARCH="$ABHOST"
 fi
-if abisdefined FAIL_ARCH && abisdefined ALLOW_ARCH; then
-	abdie "Can not define FAIL_ARCH and ALLOW_ARCH at the same time."
+if abisdefined ALLOW_ARCH; then
+	abdie "ALLOW_ARCH is deprecated, please remove it from your defines file."
 fi
 
 # NOTE: Some defines may override AB_FLAGS_* defined in an arch-specific

--- a/proc/01-core-defines.sh
+++ b/proc/01-core-defines.sh
@@ -105,6 +105,10 @@ fi
 last_status=0
 if [ "${FAIL_ARCH##\!}" != "$FAIL_ARCH" ] ; then
 	chk_op="!="
+elif [ "${FAIL_ARCH##\@}" != "$FAIL_ARCH" ] ; then
+	chk_op="=="
+elif [ "${FAIL_ARCH//[^0-9a-z-_]/}" != "$FAIL_ARCH" ] ; then
+	abdie "Invalid FAIL_ARCH expression: ‘$FAIL_ARCH’."
 else
 	chk_op="=="
 fi

--- a/sets/arch_targets.json
+++ b/sets/arch_targets.json
@@ -2,9 +2,9 @@
   "alpha": "alpha-aosc-linux-gnu",
   "amd64": "x86_64-aosc-linux-gnu",
   "arm64": "aarch64-aosc-linux-gnu",
-  "armv4": "arm-aosc-linux-gnueabi",
-  "armv6hf": "arm-aosc-linux-gnueabihf",
-  "armv7hf": "arm-aosc-linux-gnueabihf",
+  "armv4": "armv4l-aosc-linux-gnueabi",
+  "armv6hf": "armv6l-aosc-linux-gnueabihf",
+  "armv7hf": "armv7l-aosc-linux-gnueabihf",
   "i486": "i486-aosc-linux-gnu",
   "ia64": "ia64-aosc-linux-gnu",
   "loongson2f": "mips64el-aosc-linux-gnuabi64",
@@ -18,5 +18,6 @@
   "powerpc": "powerpc-aosc-linux-gnu",
   "ppc64": "powerpc64-aosc-linux-gnu",
   "ppc64el": "powerpc64le-aosc-linux-gnu",
-  "riscv64": "riscv64-aosc-linux-gnu"
+  "riscv64": "riscv64-aosc-linux-gnu",
+  "sparc64": "sparc64-aosc-linux-gnu"
 }


### PR DESCRIPTION
- Further restrict the form of the FAIL_ARCH expressions.
- Allow arch. groups in FAIL_ARCH expressions.
- Refine target triple for armv* targets.
- Deprecate ALLOW_ARCH.