### PR TITLE
arch_groups: remove with_dotnet and without_dotnet group

### DIFF
--- a/sets/arch_groups.json
+++ b/sets/arch_groups.json
@@ -48,26 +48,5 @@
     "i486",
     "m68k",
     "powerpc"
-  ],
-  "with_dotnet": [
-    "amd64",
-    "arm64",
-    "armv7hf"
-  ],
-  "without_dotnet": [
-    "loongarch64",
-    "loongarch64_nosimd",
-    "loongson3",
-    "ppc64el",
-    "riscv64",
-    "alpha",
-    "armv4",
-    "armv6hf",
-    "i486",
-    "ia64",
-    "loongson2f",
-    "m68k",
-    "powerpc",
-    "ppc64"
   ]
 }


### PR DESCRIPTION
While building .NET applications, manually disable some .NET supported architectures are usually required, due to feature imparity of .NET or native third party dependencies, and .NET SDK itself.