### PR TITLE
i486: drop RUSTFLAGS

### DIFF
--- a/arch/i486.sh
+++ b/arch/i486.sh
@@ -9,7 +9,5 @@ LDFLAGS_COMMON_ARCH=('-Wl,--gc-sections')
 
 CFLAGS_COMMON_ARCH+=('-march=i486' '-mtune=generic')
 
-RUSTFLAGS_COMMON_ARCH=('-Ctarget-cpu=i486' '-Clink-args=-latomic')
-
 # Enable Y2038 (largefile + time64) mitigation.
 AB_FLAGS_Y2038=1


### PR DESCRIPTION
The "host" rust code, like build.rs or proc_macro expander, does not accept RUSTFLAGS so this is not really useful.  Instead rustc must be patched to support the i486 target.