### PR TITLE
filters/81-pdb.sh: eliminate ShellCheck warnings

### DIFF
--- a/filters/81-pdb.sh
+++ b/filters/81-pdb.sh
@@ -3,14 +3,14 @@
 ##@copyright GPL-2.0+
 
 filter_pdb() {
-	for p in ${BIN_DIRS[@]}; do
+    for p in "${BIN_DIRS[@]}"; do
         i="$PKGDIR"/"$p"
-	    if [ -d "$i" ]; then
-            for f in `find "$i" -type f -name "*.pdb"`; do
+        if [ -d "$i" ]; then
+            for f in "$i"/**/*.pdb; do
                 if bool "$ABSPLITDBG"; then
                     path="${f#"$PKGDIR"}"
                     abinfo "Saving Program Database file $f ..."
-                    mkdir -p `dirname "$SYMDIR"/"$path"`
+                    mkdir -p "$(dirname "$SYMDIR"/"$path")"
                     mv "$f" "$SYMDIR"/"$path"
                 elif bool "$ABSTRIP"; then
                     abinfo "Dropping Program Database file $f ..."
@@ -18,7 +18,7 @@ filter_pdb() {
                 fi
             done
         fi
-	done
+    done
 }
 
 ab_register_filter pdb

--- a/filters/81-pdb.sh
+++ b/filters/81-pdb.sh
@@ -6,7 +6,7 @@ filter_pdb() {
     for p in "${BIN_DIRS[@]}"; do
         i="$PKGDIR"/"$p"
         if [ -d "$i" ]; then
-            for f in "$i"/**/*.pdb; do
+            for f in "$i"/**/*.@(pdb|dbg); do
                 if bool "$ABSPLITDBG"; then
                     path="${f#"$PKGDIR"}"
                     abinfo "Saving Program Database file $f ..."


### PR DESCRIPTION
As titled, this eliminates various ShellCheck warnings by:

* Quoting various variables,
* Switching to $(...) from legacy backticks, and
* Replacing find(1) with a glob pattern.

This PR also introduced the processing of `.dbg` files.