### PR TITLE
arch: (retro) do not specify -O level in CFLAGS_COMMON_ARCH

### DIFF
--- a/arch/armv4.sh
+++ b/arch/armv4.sh
@@ -3,7 +3,7 @@
 ##@copyright GPL-2.0+
 
 # Retro: Overriding mainline definitions, and take more interest in reducing code size.
-CFLAGS_COMMON_ARCH=('-O2' '-ffunction-sections' '-fdata-sections')
+CFLAGS_COMMON_ARCH=('-ffunction-sections' '-fdata-sections')
 CFLAGS_GCC_ARCH=('-fno-tree-ch')
 LDFLAGS_COMMON_ARCH=('-Wl,--gc-sections')
 

--- a/arch/armv6hf.sh
+++ b/arch/armv6hf.sh
@@ -3,7 +3,7 @@
 ##@copyright GPL-2.0+
 
 # Retro: Overriding mainline definitions, and take more interest in reducing code size.
-CFLAGS_COMMON_ARCH=('-O2' '-ffunction-sections' '-fdata-sections')
+CFLAGS_COMMON_ARCH=('-ffunction-sections' '-fdata-sections')
 CFLAGS_GCC_ARCH=('-fno-tree-ch')
 LDFLAGS_COMMON_ARCH=('-Wl,--gc-sections')
 

--- a/arch/armv7hf.sh
+++ b/arch/armv7hf.sh
@@ -3,7 +3,7 @@
 ##@copyright GPL-2.0+
 
 # Retro: Overriding mainline definitions, and take more interest in reducing code size.
-CFLAGS_COMMON_ARCH=('-O2' '-ffunction-sections' '-fdata-sections')
+CFLAGS_COMMON_ARCH=('-ffunction-sections' '-fdata-sections')
 CFLAGS_GCC_ARCH=('-fno-tree-ch')
 LDFLAGS_COMMON_ARCH=('-Wl,--gc-sections')
 

--- a/arch/i486.sh
+++ b/arch/i486.sh
@@ -3,7 +3,7 @@
 ##@copyright GPL-2.0+
 
 # Retro: Overriding mainline definitions, and take more interest in reducing code size.
-CFLAGS_COMMON_ARCH=('-O2' '-ffunction-sections' '-fdata-sections' '-mno-omit-leaf-frame-pointer')
+CFLAGS_COMMON_ARCH=('-ffunction-sections' '-fdata-sections' '-mno-omit-leaf-frame-pointer')
 CFLAGS_GCC_ARCH=('-fno-tree-ch')
 LDFLAGS_COMMON_ARCH=('-Wl,--gc-sections')
 

--- a/arch/ia64.sh
+++ b/arch/ia64.sh
@@ -7,7 +7,7 @@
 # quirky and slowness nature, Merced family of chips are considered
 # not well supported and quirky. GCC deprecated -mtune=itanium1 in
 # 2009 at bbb6eae87edb29b26e7c545645fac3d76a4605d8.
-CFLAGS_COMMON_ARCH=('-O2' '-mtune=itanium2')
+CFLAGS_COMMON_ARCH=('-mtune=itanium2')
 
 # NOTE: -O3 causes ICEs.
 AB_FLAGS_O3=0

--- a/arch/loongson2f.sh
+++ b/arch/loongson2f.sh
@@ -3,7 +3,7 @@
 ##@copyright GPL-2.0+
 
 # Retro: Overriding mainline definitions, and take more interest in reducing code size.
-CFLAGS_COMMON_ARCH=('-O2' '-ffunction-sections' '-fdata-sections')
+CFLAGS_COMMON_ARCH=('-ffunction-sections' '-fdata-sections')
 CFLAGS_GCC_ARCH=('-fno-tree-ch')
 LDFLAGS_COMMON_ARCH=('-Wl,--gc-sections')
 

--- a/arch/powerpc.sh
+++ b/arch/powerpc.sh
@@ -3,7 +3,7 @@
 ##@copyright GPL-2.0+
 
 # Retro: Overriding mainline definitions, and take more interest in reducing code size.
-CFLAGS_COMMON_ARCH=('-O2' '-ffunction-sections' '-fdata-sections')
+CFLAGS_COMMON_ARCH=('-ffunction-sections' '-fdata-sections')
 CFLAGS_GCC_ARCH=('-fno-tree-ch')
 LDFLAGS_COMMON_ARCH=('-Wl,--gc-sections')
 

--- a/arch/ppc64.sh
+++ b/arch/ppc64.sh
@@ -3,7 +3,7 @@
 ##@copyright GPL-2.0+
 
 # Retro: Overriding mainline definitions, and take more interest in reducing code size.
-CFLAGS_COMMON_ARCH=('-O2' '-ffunction-sections' '-fdata-sections')
+CFLAGS_COMMON_ARCH=('-ffunction-sections' '-fdata-sections')
 CFLAGS_GCC_ARCH=('-fno-tree-ch')
 LDFLAGS_COMMON_ARCH=('-Wl,--gc-sections')
 CFLAGS_COMMON_ARCH+=('-m64' '-mcpu=G5' '-maltivec' '-mabi=altivec' '-msecure-plt' '-mhard-float')

--- a/arch/sparc64.sh
+++ b/arch/sparc64.sh
@@ -3,7 +3,7 @@
 ##@copyright GPL-2.0+
 
 # Retro: Overriding mainline definitions, and take more interest in reducing code size.
-CFLAGS_COMMON_ARCH=('-O2' '-ffunction-sections' '-fdata-sections')
+CFLAGS_COMMON_ARCH=('-ffunction-sections' '-fdata-sections')
 CFLAGS_GCC_ARCH=('-fno-tree-ch')
 LDFLAGS_COMMON_ARCH=('-Wl,--gc-sections')
 


### PR DESCRIPTION
This is handled in CFLAGS_COMMON_OPTI, doing so in _ARCH renders AB_FLAGS_O* unusable.