### PR TITLE
Afterglow Ports Adjustments

### DIFF
--- a/arch/alpha.sh
+++ b/arch/alpha.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ##arch/alpha.sh: Build definitions for DEC Alpha.
 ##@copyright GPL-2.0+
-CFLAGS_COMMON_ARCH=('-mieee' '-mcpu=ev4')
+CFLAGS_COMMON_ARCH=('-mieee' '-mcpu=ev4' '-mtune=ev67')
 # Retro: Overriding mainline definitions, and take more interest in reducing code size.
 CFLAGS_COMMON_ARCH+=('-O2')
 CFLAGS_GCC_ARCH=('-fno-tree-ch')

--- a/arch/armv6hf.sh
+++ b/arch/armv6hf.sh
@@ -7,7 +7,7 @@ CFLAGS_COMMON_ARCH=('-ffunction-sections' '-fdata-sections')
 CFLAGS_GCC_ARCH=('-fno-tree-ch')
 LDFLAGS_COMMON_ARCH=('-Wl,--gc-sections')
 
-CFLAGS_COMMON_ARCH+=('-march=armv6' '-mfloat-abi=hard')
+CFLAGS_COMMON_ARCH+=('-march=armv6t2+vfpv2' '-mfloat-abi=hard')
 CFLAGS_GCC_ARCH=('-mtune=arm1176jz-s')
 
 # Enable Y2038 (largefile + time64) mitigation.

--- a/arch/armv7hf.sh
+++ b/arch/armv7hf.sh
@@ -7,7 +7,7 @@ CFLAGS_COMMON_ARCH=('-ffunction-sections' '-fdata-sections')
 CFLAGS_GCC_ARCH=('-fno-tree-ch')
 LDFLAGS_COMMON_ARCH=('-Wl,--gc-sections')
 
-CFLAGS_COMMON_ARCH+=('-march=armv7-a' '-mfloat-abi=hard' '-mfpu=neon' '-mthumb')
+CFLAGS_COMMON_ARCH+=('-march=armv7-a+neon-vfpv3' '-mfloat-abi=hard' '-mthumb')
 CFLAGS_GCC_ARCH=('-mtune=cortex-a7')
 
 # Enable Y2038 (largefile + time64) mitigation.

--- a/arch/m68k.sh
+++ b/arch/m68k.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+##arch/alpha.sh: Build definitions for DEC Alpha.
+##@copyright GPL-2.0+
+
+# Require FPU and use the new align-int ABI.
+CFLAGS_COMMON_ARCH=('-march=68020' '-mtune=68020-60' '-mhard-float' '-malign-int')
+# Retro: Overriding mainline definitions, and take more interest in reducing code size.
+CFLAGS_COMMON_ARCH+=('-O2')
+CFLAGS_GCC_ARCH=('-fno-tree-ch')
+
+# Enable Y2038 (largefile + time64) mitigation.
+AB_FLAGS_Y2038=1

--- a/arch/powerpc.sh
+++ b/arch/powerpc.sh
@@ -7,7 +7,7 @@ CFLAGS_COMMON_ARCH=('-ffunction-sections' '-fdata-sections')
 CFLAGS_GCC_ARCH=('-fno-tree-ch')
 LDFLAGS_COMMON_ARCH=('-Wl,--gc-sections')
 
-CFLAGS_COMMON_ARCH+=('-m32' '-mcpu=603' '-mtune=G4' '-mno-altivec' '-msecure-plt' '-mhard-float')
+CFLAGS_COMMON_ARCH+=('-m32' '-mcpu=603' '-mtune=G4' '-mno-altivec' '-mno-vsx' '-msecure-plt' '-mhard-float')
 
 # Position-independent executable buildmode is not available on PowerPC 32-bit architecture.
 # Removing for powerpc target.

--- a/arch/ppc64.sh
+++ b/arch/ppc64.sh
@@ -6,7 +6,7 @@
 CFLAGS_COMMON_ARCH=('-ffunction-sections' '-fdata-sections')
 CFLAGS_GCC_ARCH=('-fno-tree-ch')
 LDFLAGS_COMMON_ARCH=('-Wl,--gc-sections')
-CFLAGS_COMMON_ARCH+=('-m64' '-mcpu=G5' '-maltivec' '-mabi=altivec' '-msecure-plt' '-mhard-float')
+CFLAGS_COMMON_ARCH+=('-m64' '-mcpu=powerpc64' '-mtune=G5' '-maltivec' '-mno-vsx' '-mabi=ibmlongdouble' '-msecure-plt' '-mhard-float')
 
 # Override some RUSTFLAGS sure that the correct linker is used with NOLTO=1.
 CFLAGS_GCC_OPTI_LTO=("${CFLAGS_COMMON_ARCH_LTO[@]}" '-flto-partition=none')

--- a/arch/sparc64.sh
+++ b/arch/sparc64.sh
@@ -7,6 +7,6 @@ CFLAGS_COMMON_ARCH=('-ffunction-sections' '-fdata-sections')
 CFLAGS_GCC_ARCH=('-fno-tree-ch')
 LDFLAGS_COMMON_ARCH=('-Wl,--gc-sections')
 
-CFLAGS_COMMON_ARCH+=('-march=v9' '-mvis' '-m64' '-mcmodel=medany')
+CFLAGS_COMMON_ARCH+=('-mcpu=ultrasparc' '-mvis' '-m64' '-mcmodel=medany')
 
-RUSTFLAGS_COMMON_ARCH=('-Ctarget-cpu=v9' '-Ctarget-feature=+vis' '-Ccode-model=medium')
+RUSTFLAGS_COMMON_ARCH=('-Ctarget-cpu=ultrasparc' '-Ctarget-feature=+vis' '-Ccode-model=medium')

--- a/native/abnativeelf.cpp
+++ b/native/abnativeelf.cpp
@@ -398,6 +398,8 @@ const AOSCArch detect_architecture(Elf *elf_file, GElf_Ehdr &elf_ehdr,
     return AOSCArch::IA64;
   case EM_ALPHA:
     return AOSCArch::ALPHA;
+  case EM_68K:
+    return AOSCArch::M68K;
   default:
     return AOSCArch::NONE;
   }
@@ -573,6 +575,8 @@ static const AOSCArch parse_aosc_arch_name(const std::string &name) {
     return AOSCArch::LOONGSON2F;
   if (name == "loongson3")
     return AOSCArch::LOONGSON3;
+  if (name == "m68k")
+    return AOSCArch::M68K;
   if (name == "mips64r6el")
     return AOSCArch::MIPS64R6EL;
   if (name == "powerpc")
@@ -612,6 +616,8 @@ aosc_arch_to_debian_arch_suffix(const AOSCArch arch) {
   case AOSCArch::LOONGSON2F:
   case AOSCArch::LOONGSON3:
     return {"mips64el"};
+  case AOSCArch::M68K:
+    return {"m68k"};
   case AOSCArch::MIPS64R6EL:
     return {"mips64r6el"};
   case AOSCArch::POWERPC:

--- a/native/abnativeelf.hpp
+++ b/native/abnativeelf.hpp
@@ -30,6 +30,7 @@ enum class AOSCArch : uint8_t {
   LOONGARCH64,
   LOONGSON2F,
   LOONGSON3,
+  M68K,
   MIPS64R6EL,
   POWERPC,
   PPC64,


### PR DESCRIPTION
- Add m68k definitions.
- alpha: tune for EV67 (AlphaStation DS10).