### PR TITLE
Add ARMv5TE architecture

### DIFF
--- a/arch/armv5te.sh
+++ b/arch/armv5te.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+##arch/armv5te.sh: Build definitions for ARMv5TE (soft-float).
+##@copyright GPL-2.0+
+
+# Retro: Override mainline definitions and prioritise smaller binaries.
+CFLAGS_COMMON_ARCH=('-ffunction-sections' '-fdata-sections')
+CFLAGS_GCC_ARCH=('-fno-tree-ch')
+LDFLAGS_COMMON_ARCH=('-Wl,--gc-sections')
+
+CFLAGS_COMMON_ARCH+=('-march=armv5te' '-mfloat-abi=soft')
+CFLAGS_GCC_ARCH+=('-mtune=arm926ej-s')
+
+# Enable Y2038 (largefile + time64) mitigation.
+AB_FLAGS_Y2038=1

--- a/native/abnativeelf.cpp
+++ b/native/abnativeelf.cpp
@@ -245,6 +245,10 @@ static AOSCArch get_elf_arm_arch(Elf *elf_file, Endianness endianness,
         case 1:
           ret = AOSCArch::ARMV4;
           break;
+        // v5TE
+        case 4:
+          ret = AOSCArch::ARMV5TE;
+          break;
         // v6
         case 6:
           ret = AOSCArch::ARMV6HF;
@@ -267,7 +271,8 @@ static AOSCArch get_elf_arm_arch(Elf *elf_file, Endianness endianness,
     }
   }
   // Detect unsupported combinations
-  if ((ret == AOSCArch::ARMV4) && hard_float) {
+  if (((ret == AOSCArch::ARMV4) || (ret == AOSCArch::ARMV5TE)) &&
+      hard_float) {
     return AOSCArch::NONE;
   } else if (((ret == AOSCArch::ARMV6HF) || (ret == AOSCArch::ARMV7HF)) &&
              (!hard_float)) {
@@ -552,6 +557,8 @@ static const AOSCArch parse_aosc_arch_name(const std::string &name) {
     return AOSCArch::ARM64;
   if (name == "armv4")
     return AOSCArch::ARMV4;
+  if (name == "armv5te")
+    return AOSCArch::ARMV5TE;
   if (name == "armv6hf")
     return AOSCArch::ARMV6HF;
   if (name == "armv7hf")
@@ -591,6 +598,7 @@ aosc_arch_to_debian_arch_suffix(const AOSCArch arch) {
   case AOSCArch::ARM64:
     return {"arm64"};
   case AOSCArch::ARMV4:
+  case AOSCArch::ARMV5TE:
     return {"armel"};
   case AOSCArch::ARMV6HF:
   case AOSCArch::ARMV7HF:

--- a/native/abnativeelf.hpp
+++ b/native/abnativeelf.hpp
@@ -22,6 +22,7 @@ enum class AOSCArch : uint8_t {
   AMD64,
   ARM64,
   ARMV4,
+  ARMV5TE,
   ARMV6HF,
   ARMV7HF,
   I486,

--- a/sets/arch_groups.json
+++ b/sets/arch_groups.json
@@ -10,11 +10,12 @@
   ],
   "mainline_tier1": ["amd64", "arm64", "loongarch64", "loongarch64_nosimd"],
   "mainline_tier2": ["loongson3", "ppc64el", "riscv64"],
-  "arm": ["armv4", "armv6hf", "armv7hf", "arm64"],
+  "arm": ["armv4", "armv5te", "armv6hf", "armv7hf", "arm64"],
   "ocaml_native": ["amd64", "arm64", "ppc64el"],
   "retro": [
     "alpha",
     "armv4",
+    "armv5te",
     "armv6hf",
     "armv7hf",
     "i486",

--- a/sets/arch_targets.json
+++ b/sets/arch_targets.json
@@ -3,6 +3,7 @@
   "amd64": "x86_64-aosc-linux-gnu",
   "arm64": "aarch64-aosc-linux-gnu",
   "armv4": "armv4l-aosc-linux-gnueabi",
+  "armv5te": "armv5l-aosc-linux-gnueabi",
   "armv6hf": "armv6l-aosc-linux-gnueabihf",
   "armv7hf": "armv7l-aosc-linux-gnueabihf",
   "i486": "i486-aosc-linux-gnu",


### PR DESCRIPTION
Register ARMv5TE throughout Autobuild4.

- arch/armv5te.sh: Add the ARMv5TE soft-float profile, ARM926EJ-S tuning, Retro size optimizations, and Y2038 settings.
- native/abnativeelf.hpp: Add the ARMV5TE architecture enum.
- native/abnativeelf.cpp: Detect ARMv5TE ELF attributes, parse the armv5te name, reject hard-float binaries, and map ARMv5TE to the armel ABI suffix.
- sets/arch_targets.json: Register armv5te with the armv5l-aosc-linux-gnueabi target triplet.
- sets/arch_groups.json: Add armv5te to the appropriate ARM and Retro architecture groups.

This commit is authored with assistance from AI/LLM:

- Model: GPT-5.6 Luna
- Platform: OpenAI API (https://platform.openai.com/)
- Agent platform: OpenAI Codex (https://openai.com/codex/)

- Prompt:
  I am bootstrapping AOSC OS for ARMv5TE. Using the existing ARM architecture
  implementations in Autobuild4 as references, inspect the Autobuild4 and Kaboom2 worktrees; implement and validate the required ARMv5TE support; and
  record the work in reproducible documentation.

The contributor reviewed and understood the changes, participated in the implementation and validation, and remains responsible for the final result.