### PR TITLE
sets: add riscv64 to ocaml_native

### DIFF
--- a/sets/arch_groups.json
+++ b/sets/arch_groups.json
@@ -11,7 +11,7 @@
   "mainline_tier1": ["amd64", "arm64", "loongarch64", "loongarch64_nosimd"],
   "mainline_tier2": ["loongson3", "ppc64el", "riscv64"],
   "arm": ["armv4", "armv5te", "armv6hf", "armv7hf", "arm64"],
-  "ocaml_native": ["amd64", "arm64", "ppc64el"],
+  "ocaml_native": ["amd64", "arm64", "ppc64el", "riscv64"],
   "retro": [
     "alpha",
     "armv4",


### PR DESCRIPTION
Ref: https://ocaml.org/tools/native-target#platform-support